### PR TITLE
Fix truncate_text length handling and add tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure repository root is on sys.path for tests
+repo_root = os.path.dirname(__file__)
+if repo_root not in sys.path:
+    sys.path.insert(0, repo_root)

--- a/python/helpers/strings.py
+++ b/python/helpers/strings.py
@@ -125,10 +125,16 @@ def truncate_text(text: str, length: int, at_end: bool = True, replacement: str 
     orig_length = len(text)
     if orig_length <= length:
         return text
+
+    # When length is shorter than or equal to the replacement, return a slice of the replacement
+    if length <= len(replacement):
+        return replacement[:length]
+
+    keep = length - len(replacement)
     if at_end:
-         return text[:length] + replacement
+        return text[:keep] + replacement
     else:
-        return replacement + text[-length:]
+        return replacement + text[-keep:]
     
 def truncate_text_by_ratio(text: str, threshold: int, replacement: str = "...", ratio: float = 0.5) -> str:
     """Truncate text with replacement at a specified ratio position."""

--- a/python/helpers/test_strings.py
+++ b/python/helpers/test_strings.py
@@ -1,0 +1,23 @@
+import pytest
+
+from python.helpers.strings import truncate_text
+
+
+def test_truncate_text_end_respects_length():
+    text = "abcdefghijklmnopqrstuvwxyz"
+    result = truncate_text(text, 10)
+    assert result == "abcdefg..."
+    assert len(result) == 10
+
+
+def test_truncate_text_start_respects_length():
+    text = "abcdefghijklmnopqrstuvwxyz"
+    result = truncate_text(text, 10, at_end=False)
+    assert result == "...tuvwxyz"
+    assert len(result) == 10
+
+
+def test_truncate_text_replacement_longer_than_length():
+    text = "hello"
+    result = truncate_text(text, 2)
+    assert result == ".."


### PR DESCRIPTION
## Summary
- ensure `truncate_text` doesn't exceed requested length and handles short lengths
- add tests for `truncate_text`
- make repository root importable in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688aa2c88d148327813a6ff159c05dc4