### PR TITLE
Use run_ui.py as Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY src/ ./src/
+# Copy the entire project into the image
+COPY . .
 
-CMD ["python", "src/main.py"]
+# Launch the web UI
+CMD ["python", "run_ui.py"]

--- a/README_ARIA_NOTES.md
+++ b/README_ARIA_NOTES.md
@@ -4,6 +4,6 @@
 - Added instruments: Stripe, Instagram, ElevenLabs, Stable Diffusion (each with run.sh).
 - instruments.py import stubs added.
 - agents/egirl/ persona folder added with prompts.
-- main.py loads persona prompt.
+- run_ui.py loads persona prompt.
 - Dockerfile: please ensure deps installed (stripe, requests, elevenlabs, or diffusers stack).
 - Secrets: DO NOT COMMIT .env. Set at runtime.


### PR DESCRIPTION
## Summary
- fix Dockerfile to copy project and run `run_ui.py`
- update Aria notes to reference `run_ui.py`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b42951c98832782de3634f01d72da