### PR TITLE
Add GPT-5 tool framework for Aria with TTS and Instagram stubs

### DIFF
--- a/python/helpers/aria_tools.py
+++ b/python/helpers/aria_tools.py
@@ -1,0 +1,164 @@
+import json
+import os
+from typing import Any, List, Dict, Tuple
+
+try:
+    from openai import OpenAI
+except Exception:  # pragma: no cover - optional dependency
+    OpenAI = None  # type: ignore
+
+try:
+    from elevenlabs.client import ElevenLabs
+except Exception:  # pragma: no cover - optional dependency
+    ElevenLabs = None  # type: ignore
+
+# initialize OpenAI client if library available
+client = OpenAI() if OpenAI else None
+
+# tool definitions for Aria
+ARIA_TOOLS: List[Dict[str, Any]] = [
+    {
+        "type": "custom",
+        "name": "sd_image",
+        "description": "Generate an image from a text prompt using Stable Diffusion.",
+    },
+    {
+        "type": "custom",
+        "name": "eleven_tts",
+        "description": "Convert text to speech using ElevenLabs.",
+    },
+    {
+        "type": "function",
+        "name": "post_to_instagram",
+        "description": "Post an image with a caption to Instagram.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "image_path": {"type": "string"},
+                "caption": {"type": "string"},
+            },
+            "required": ["image_path", "caption"],
+        },
+    },
+]
+
+# allowed tool groupings
+ALLOWED_IMAGE = [{"type": "custom", "name": "sd_image"}]
+ALLOWED_TTS = [{"type": "custom", "name": "eleven_tts"}]
+ALLOWED_INSTAGRAM = [{"type": "function", "name": "post_to_instagram"}]
+
+def gpt5(
+    prompt: Any,
+    tools: List[Dict[str, Any]] | None = None,
+    allowed: List[Dict[str, str]] | None = None,
+    effort: str = "minimal",
+    verbosity: str = "low",
+    system_preamble: str | None = None,
+    previous_response_id: str | None = None,
+):
+    """Helper around the Responses API with reasoning/verbosity controls."""
+    if not client:
+        raise RuntimeError("OpenAI client not available")
+
+    kwargs: Dict[str, Any] = {
+        "model": "gpt-5",
+        "input": prompt,
+        "reasoning": {"effort": effort},
+        "text": {"verbosity": verbosity},
+    }
+    if tools:
+        kwargs["tools"] = tools
+    if allowed:
+        kwargs["tool_choice"] = {
+            "type": "allowed_tools",
+            "mode": "auto",
+            "tools": allowed,
+        }
+    if system_preamble:
+        kwargs["system"] = system_preamble
+    if previous_response_id:
+        kwargs["previous_response_id"] = previous_response_id
+    return client.responses.create(**kwargs)
+
+
+def _sd_generate(prompt: str) -> str:
+    """Stub for Stable Diffusion image generation."""
+    filename = f"sd_image_generated_for_{prompt.replace(' ', '_')}.png"
+    return filename
+
+
+def _eleven_tts(text: str) -> str:
+    """Convert text to speech with ElevenLabs if available."""
+    api_key = os.getenv("ELEVENLABS_API_KEY")
+    voice_id = os.getenv("PERSONA_VOICE_ID")
+    if ElevenLabs and api_key and voice_id:
+        try:
+            client = ElevenLabs(api_key=api_key)
+            audio = client.text_to_speech.convert(
+                voice_id=voice_id,
+                model_id="eleven_multilingual_v2",
+                text=text,
+                output_format="mp3_44100_128",
+            )
+            os.makedirs("outputs", exist_ok=True)
+            path = os.path.join("outputs", "aria_tts.mp3")
+            with open(path, "wb") as f:
+                for chunk in audio:
+                    if chunk:
+                        f.write(chunk)
+            return path
+        except Exception:
+            pass
+    return ""
+
+
+def _post_to_instagram(image_path: str, caption: str) -> str:
+    """Placeholder for posting to Instagram."""
+    return f"posted {image_path} with caption {caption}"
+
+
+def handle_tool_call(msg: Any) -> Tuple[Any, str | None]:
+    """Handle tool calls returned by the model.
+
+    Returns a tuple of (followup_response, result_value)
+    where result_value may be a path or message from the tool.
+    """
+    if not client:
+        raise RuntimeError("OpenAI client not available")
+
+    if getattr(msg, "type", None) != "tool_call":
+        return msg, None
+
+    name = getattr(msg, "name", "")
+    result: str | None = None
+    if name == "sd_image":
+        prompt = getattr(msg, "arguments", "")
+        result = _sd_generate(prompt)
+    elif name == "eleven_tts":
+        text = getattr(msg, "arguments", "")
+        result = _eleven_tts(text)
+    elif name == "post_to_instagram":
+        args = getattr(msg, "arguments", {})
+        if isinstance(args, str):
+            try:
+                args = json.loads(args)
+            except Exception:
+                args = {}
+        image_path = args.get("image_path", "")
+        caption = args.get("caption", "")
+        result = _post_to_instagram(image_path, caption)
+    else:
+        return msg, None
+
+    followup = client.responses.create(
+        model="gpt-5",
+        input=[
+            {
+                "role": "tool",
+                "content": json.dumps({"result": result}),
+                "tool_call_id": getattr(msg, "id", ""),
+            }
+        ],
+        previous_response_id=getattr(msg, "response_id", None),
+    )
+    return followup, result


### PR DESCRIPTION
## Summary
- add `aria_tools` module defining Stable Diffusion image, ElevenLabs TTS, and Instagram posting tools
- wrap GPT-5 Responses API with reasoning/verbosity and allowed-tools gating
- wire PersonaEngine to use GPT-5 with ElevenLabs TTS tool handling

## Testing
- `python -m py_compile python/helpers/aria_tools.py python/helpers/egirl/persona.py`


------
https://chatgpt.com/codex/tasks/task_e_689b578a681483278339ca9716132dd6