### PR TITLE
Fix backup_test module import for pytest

### DIFF
--- a/python/api/__init__.py
+++ b/python/api/__init__.py
@@ -1,0 +1,1 @@
+"""API endpoint handlers package."""

--- a/python/api/backup_test.py
+++ b/python/api/backup_test.py
@@ -1,5 +1,15 @@
-from python.helpers.api import ApiHandler, Request, Response
-from python.helpers.backup import BackupService
+"""API endpoint to test backup file selection patterns.
+
+Pytest attempts to collect any file ending with ``_test.py`` as a test
+module.  When run from the repository root the absolute imports used here
+(`python.helpers...`) fail because the ``python`` package isn't installed on
+the import path.  Using package-relative imports avoids this issue and keeps
+the module importable both by the application and by the test runner without
+requiring any path manipulation.
+"""
+
+from ..helpers.api import ApiHandler, Request, Response
+from ..helpers.backup import BackupService
 
 
 class BackupTest(ApiHandler):


### PR DESCRIPTION
## Summary
- fix ModuleNotFoundError in `backup_test` by using package-relative imports
- declare `python.api` as a package

## Testing
- `pytest -q`
- `python -m py_compile python/api/backup_test.py python/api/__init__.py`
- `git ls-files '*.js' | xargs -n1 node --check`


------
https://chatgpt.com/codex/tasks/task_e_689f8f1655948327afbb5940f6fe6f42