### PR TITLE
Add screenwriting instruments and formatter agent

### DIFF
--- a/agents/screenwriting/__init__.py
+++ b/agents/screenwriting/__init__.py
@@ -7,6 +7,7 @@ from .dialogue_evaluator import DialogueEvaluator
 from .emotional_tension import EmotionalTension
 from .marketability import Marketability
 from .plot_analyzer import PlotAnalyzer
+from .script_formatter import ScriptFormatter
 from .version_tracker import VersionTracker
 
 __all__ = [
@@ -17,5 +18,6 @@ __all__ = [
     "EmotionalTension",
     "Marketability",
     "PlotAnalyzer",
+    "ScriptFormatter",
     "VersionTracker",
 ]

--- a/agents/screenwriting/_context.md
+++ b/agents/screenwriting/_context.md
@@ -1,3 +1,5 @@
 # Screenwriting Team
 - Collection of specialized agents focused on screenplay development
 - Each agent leverages available tools and instruments for its tasks
+- Instruments include `script_analyzer` for structural metrics and `fountain_to_html` for formatting
+- Contains a `ScriptFormatter` agent to render Fountain scripts as HTML

--- a/agents/screenwriting/character_analyzer.py
+++ b/agents/screenwriting/character_analyzer.py
@@ -15,6 +15,7 @@ class CharacterAnalyzer(Agent):
         The agent may invoke tools and instruments to support its reasoning.
         """
         self.hist_add_user_message(
-            "Use available tools to analyze the characters in the following script:\n" + script
+            "Use tools like the script_analyzer instrument to analyze the characters in the following script:\n"
+            + script
         )
         return await self.monologue()

--- a/agents/screenwriting/plot_analyzer.py
+++ b/agents/screenwriting/plot_analyzer.py
@@ -15,6 +15,7 @@ class PlotAnalyzer(Agent):
         Makes use of tools and instruments for deeper inspection.
         """
         self.hist_add_user_message(
-            "Use tools and instruments to analyze the plot structure of:\n" + outline
+            "Use tools such as the script_analyzer instrument to analyze the plot structure of:\n"
+            + outline
         )
         return await self.monologue()

--- a/agents/screenwriting/script_formatter.py
+++ b/agents/screenwriting/script_formatter.py
@@ -1,0 +1,17 @@
+"""Agent that formats a script into shareable HTML."""
+
+from agents import Agent, AgentConfig
+
+
+class ScriptFormatter(Agent):
+    """Produce formatted HTML from a Fountain script."""
+
+    def __init__(self, number: int, config: AgentConfig, context=None):
+        super().__init__(number, config, context)
+
+    async def format(self, script: str) -> str:
+        """Return HTML representation using the fountain_to_html instrument."""
+        self.hist_add_user_message(
+            "Use the fountain_to_html instrument to render this script:\n" + script
+        )
+        return await self.monologue()

--- a/instruments/default/fountain_to_html/fountain_to_html.md
+++ b/instruments/default/fountain_to_html/fountain_to_html.md
@@ -1,0 +1,13 @@
+# Problem
+Convert a Fountain screenplay file to HTML for preview.
+
+# Solution
+1. If needed, change directory to the location of your `.fountain` file.
+2. Run:
+
+```bash
+bash /a0/instruments/default/fountain_to_html/fountain_to_html.sh <script.fountain>
+```
+
+3. Replace `<script.fountain>` with your file path.
+4. HTML output is printed to stdout; redirect to a file if desired.

--- a/instruments/default/fountain_to_html/fountain_to_html.py
+++ b/instruments/default/fountain_to_html/fountain_to_html.py
@@ -1,0 +1,18 @@
+import sys
+import html as html_lib
+
+
+def main(path: str) -> None:
+    with open(path, "r", encoding="utf-8") as f:
+        script = f.read()
+
+    escaped = html_lib.escape(script)
+    output = f"<pre>{escaped}</pre>"
+    print(output)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python3 fountain_to_html.py <path_to_fountain>")
+        sys.exit(1)
+    main(sys.argv[1])

--- a/instruments/default/fountain_to_html/fountain_to_html.sh
+++ b/instruments/default/fountain_to_html/fountain_to_html.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 /a0/instruments/default/fountain_to_html/fountain_to_html.py "$1"

--- a/instruments/default/script_analyzer/analyze_script.py
+++ b/instruments/default/script_analyzer/analyze_script.py
@@ -1,0 +1,54 @@
+import sys
+import json
+import re
+from collections import Counter
+
+
+def extract_scenes(lines):
+    scene_regex = re.compile(r"^(INT|EXT|EST|INT./EXT.|INT/EXT|EXT./INT.)", re.IGNORECASE)
+    return [line.strip() for line in lines if scene_regex.match(line.strip())]
+
+
+def extract_characters(lines):
+    characters = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.isupper() and 0 < len(stripped.split()) <= 4 and not stripped.startswith(("INT", "EXT", "EST")):
+            characters.append(stripped)
+    return characters
+
+
+def analyze_script(path):
+    with open(path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    scenes = extract_scenes(lines)
+    characters = extract_characters(lines)
+
+    char_counts = Counter()
+    current_char = None
+    for line in lines:
+        stripped = line.strip()
+        if stripped in characters:
+            current_char = stripped
+        elif current_char and stripped:
+            char_counts[current_char] += 1
+        elif not stripped:
+            current_char = None
+
+    report = {
+        "scenes": len(scenes),
+        "characters": sorted(set(characters)),
+        "dialogue_lines": char_counts,
+    }
+    return report
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python3 analyze_script.py <path_to_script>")
+        sys.exit(1)
+
+    result = analyze_script(sys.argv[1])
+    result["dialogue_lines"] = dict(result["dialogue_lines"])
+    print(json.dumps(result, indent=2))

--- a/instruments/default/script_analyzer/script_analyzer.md
+++ b/instruments/default/script_analyzer/script_analyzer.md
@@ -1,0 +1,13 @@
+# Problem
+Analyze screenplay structure and dialogue distribution.
+
+# Solution
+1. If the file is stored elsewhere, change directory to it.
+2. Run the analyzer with the screenplay path:
+
+```bash
+bash /a0/instruments/default/script_analyzer/script_analyzer.sh <path>
+```
+
+3. Replace `<path>` with your script file.
+4. The command prints JSON with scene count, character list, and dialogue line tallies.

--- a/instruments/default/script_analyzer/script_analyzer.sh
+++ b/instruments/default/script_analyzer/script_analyzer.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 /a0/instruments/default/script_analyzer/analyze_script.py "$1"


### PR DESCRIPTION
## Summary
- introduce `script_analyzer` instrument to collect scene and dialogue metrics
- add `fountain_to_html` instrument for rendering Fountain scripts
- create `ScriptFormatter` agent and wire instruments into screenwriting agents

## Testing
- `python -m py_compile instruments/default/script_analyzer/analyze_script.py instruments/default/fountain_to_html/fountain_to_html.py agents/screenwriting/script_formatter.py agents/screenwriting/character_analyzer.py agents/screenwriting/plot_analyzer.py agents/screenwriting/__init__.py`
- `python instruments/default/script_analyzer/analyze_script.py tmp/sample_script.txt`
- `python instruments/default/fountain_to_html/fountain_to_html.py tmp/sample_script.fountain | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_689f95ea899483279b968b2ba8f938cf