### PR TITLE
Fix legacy pattern parsing in backup test endpoint

### DIFF
--- a/python/api/backup_test.py
+++ b/python/api/backup_test.py
@@ -31,7 +31,9 @@ class BackupTest(ApiHandler):
 
             # Support legacy string patterns format for backward compatibility
             patterns_string = input.get("patterns", "")
-            if patterns_string and not include_patterns:
+            # Only parse legacy patterns string when pattern arrays are absent
+            # to maintain backward compatibility without mixing formats.
+            if patterns_string and not include_patterns and not exclude_patterns:
                 # Parse patterns string into arrays
                 lines = [line.strip() for line in patterns_string.split('\n') if line.strip() and not line.strip().startswith('#')]
                 for line in lines:


### PR DESCRIPTION
## Summary
- avoid mixing legacy patterns string with pattern arrays in backup test endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a16f603d38832794c70d6342dc75e2