### PR TITLE
Use OpenRouter API base for egirl agent

### DIFF
--- a/conf/model_providers.yaml
+++ b/conf/model_providers.yaml
@@ -51,6 +51,7 @@ chat:
     name: OpenRouter
     litellm_provider: openrouter
     kwargs:
+      api_base: https://openrouter.ai/api/v1
       extra_headers:
         "HTTP-Referer": "https://agent-zero.ai/"
         "X-Title": "Agent Zero"


### PR DESCRIPTION
## Summary
- configure OpenRouter provider with explicit API base URL

## Testing
- `python -m py_compile run_ui.py models.py python/helpers/settings.py`
- `python - <<'PY'
from models import get_chat_model
m = get_chat_model('openrouter', 'openai/gpt-4.1')
print(m.kwargs)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68aba6671f88832789cca79a93c888fb