### PR TITLE
fix run_ui port binding and add pathspec requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,6 +42,7 @@ open-clip-torch
 openai>=1.30.0
 openai-whisper==20240930
 paramiko==3.5.0
+pathspec
 peft>=0.10.0
 pillow>=10.3.0
 pillow-avif-plugin==1.4.3

--- a/run_ui.py
+++ b/run_ui.py
@@ -179,7 +179,7 @@ def run():
             pass  # Override to suppress request logging
 
     # Get configuration from environment
-    port = runtime.get_web_ui_port()
+    port = int(os.getenv("PORT") or runtime.get_web_ui_port())
     host = (
         runtime.get_arg("host") or dotenv.get_dotenv_value("WEB_UI_HOST") or "localhost"
     )
@@ -221,8 +221,6 @@ def run():
         },
     )
 
-    PrintStyle().debug(f"Starting server at http://{host}:{port} ...")
-
     server = make_server(
         host=host,
         port=port,
@@ -231,6 +229,9 @@ def run():
         threaded=True,
     )
     process.set_server(server)
+    port = server.server_port
+    runtime.args["port"] = port
+    PrintStyle().debug(f"Starting server at http://{host}:{port} ...")
     server.log_startup()
 
     # Start init_a0 in a background thread when server starts


### PR DESCRIPTION
## Summary
- fix run_ui to prefer `PORT` env var and update runtime args after binding so the server advertises the correct port
- add missing `pathspec` package to requirements

## Testing
- `python -m py_compile run_ui.py`
- `python -m py_compile python/helpers/backup.py`
- `python - <<'PY'
import pathspec, sys
print('pathspec version', pathspec.__version__)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68af39605f9483279f3a31dc32dec330