### PR TITLE
Enable egirl agent to use SD, 11Labs, and Stripe tools

### DIFF
--- a/agents/egirl/prompts/agent.system.tool.egirl_tool.md
+++ b/agents/egirl/prompts/agent.system.tool.egirl_tool.md
@@ -1,10 +1,10 @@
 # EgirlTool
 - Use `task: post_instagram` with `image_url` and `caption` to publish a picture.
 - Use `task: comment_instagram` with `hashtags`, `text`, and optional `max_posts` to comment on posts.
-- Use `task: generate_image` with `prompt` and optional `output_path` to create a persona image.
+- Use `task: generate_image` with `prompt` and optional `output_dir` to create an image via Stable Diffusion.
 - Use `task: generate_video` with `image_path`, `prompt`, and optional `output_path` to create a short clip.
-- Use `task: generate_voice` with `text` and optional `output_path` for text-to-speech.
-- Use `task: stripe_payment` with `price_id` to create a checkout link.
+- Use `task: generate_voice` with `text` and optional `output_path` for ElevenLabs text-to-speech.
+- Use `task: stripe_payment` with `price_id` to create a Stripe checkout link.
 - Use `task: stripe_subscription` with `price_id` to start a subscription.
 - Use `task: stripe_refund` with `payment_intent` to refund a payment.
 - Use `task: stripe_payout` with `amount` and optional `currency` to issue a payout.

--- a/python/helpers/egirl/stripe.py
+++ b/python/helpers/egirl/stripe.py
@@ -1,4 +1,6 @@
-import os, logging
+import os
+import logging
+
 try:
     import stripe
 except Exception as e:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- Generate images with Stable Diffusion through egirl tool and return results from persona chat
- Add Stripe checkout support to Aria toolset and allow SD/Stripe/ElevenLabs in persona engine
- Fix Stripe helper imports

## Testing
- `python -m py_compile agents/egirl/tools/egirl_tool.py python/helpers/aria_tools.py python/helpers/egirl/persona.py python/helpers/egirl/stripe.py`
- `pytest >/tmp/pytest.log 2>&1; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b446ee0b908327b206913e1875aa19