### PR TITLE
Use non-blocking sleep in local shell

### DIFF
--- a/python/helpers/shell_local.py
+++ b/python/helpers/shell_local.py
@@ -1,3 +1,4 @@
+import asyncio
 import select
 import subprocess
 import time
@@ -60,7 +61,7 @@ class LocalInteractiveSession:
                 if line:
                     partial_output += line
                     self.full_output += line
-                    time.sleep(0.1)
+                    await asyncio.sleep(0.1)
                 else:
                     break  # No more output
             else:


### PR DESCRIPTION
## Summary
- import asyncio in `shell_local` helper
- await `asyncio.sleep` instead of blocking `time.sleep`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b47959e3e48327be7682c3af5105a9