### PR TITLE
Enforce positive timeout in LocalInteractiveSession read_output

### DIFF
--- a/python/helpers/shell_local.py
+++ b/python/helpers/shell_local.py
@@ -44,16 +44,19 @@ class LocalInteractiveSession:
         self.process.stdin.write(command + '\n') # type: ignore
         self.process.stdin.flush() # type: ignore
  
-    async def read_output(self, timeout: float = 0, reset_full_output: bool = False) -> Tuple[str, Optional[str]]:
+    async def read_output(self, timeout: float = 5.0, reset_full_output: bool = False) -> Tuple[str, Optional[str]]:
         if not self.process:
             raise Exception("Shell not connected")
+
+        if timeout <= 0:
+            raise ValueError("timeout must be positive")
 
         if reset_full_output:
             self.full_output = ""
         partial_output = ''
         start_time = time.time()
-        
-        while (timeout <= 0 or time.time() - start_time < timeout):
+
+        while time.time() - start_time < timeout:
             rlist, _, _ = select.select([self.process.stdout], [], [], 0.1)
             if rlist:
                 line = self.process.stdout.readline()  # type: ignore
@@ -68,5 +71,5 @@ class LocalInteractiveSession:
 
         if not partial_output:
             return self.full_output, None
-        
+
         return self.full_output, partial_output


### PR DESCRIPTION
## Summary
- guard `LocalInteractiveSession.read_output` against zero or negative timeouts by requiring a positive timeout
- default to a 5 second timeout and loop only until that duration elapses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4795de1d0832780e0d52532f57c84