### PR TITLE
Add screenwriting and egirl UI components

### DIFF
--- a/ui-kit-react/src/App.jsx
+++ b/ui-kit-react/src/App.jsx
@@ -3,17 +3,44 @@ import AgentLauncher from './components/AgentLauncher';
 import AgentModal from './components/AgentModal';
 import AgentChat from './components/AgentChat';
 import AgentLogView from './components/AgentLogView';
+import ScreenwritingUI from './components/ScreenwritingUI';
+import EgirlUI from './components/EgirlUI';
 import config from '../agent.config.json';
 
 export default function App() {
   const [open, setOpen] = useState(false);
   const [logs, setLogs] = useState([]);
+  const [ui, setUI] = useState('default');
+
+  const handleLog = (log) => {
+    setLogs((prev) => [...prev, log]);
+  };
+
+  const renderUI = () => {
+    switch (ui) {
+      case 'screenwriting':
+        return <ScreenwritingUI onLog={handleLog} />;
+      case 'egirl':
+        return <EgirlUI onLog={handleLog} />;
+      default:
+        return <AgentChat onLog={handleLog} />;
+    }
+  };
 
   return (
     <div className="app-container" data-theme={config.theme || 'light'}>
       <AgentLauncher onOpen={() => setOpen(true)} />
       <AgentModal open={open} onClose={() => setOpen(false)}>
-        <AgentChat onLog={(log) => setLogs((prev) => [...prev, log])} />
+        <select
+          className="ui-select"
+          value={ui}
+          onChange={(e) => setUI(e.target.value)}
+        >
+          <option value="default">Default</option>
+          <option value="screenwriting">Screenwriting</option>
+          <option value="egirl">E-Girl</option>
+        </select>
+        {renderUI()}
         <AgentLogView logs={logs} />
       </AgentModal>
     </div>

--- a/ui-kit-react/src/components/EgirlUI.jsx
+++ b/ui-kit-react/src/components/EgirlUI.jsx
@@ -1,0 +1,10 @@
+import AgentChat from './AgentChat';
+
+export default function EgirlUI({ onLog }) {
+  return (
+    <div className="egirl-ui">
+      <h2>E-Girl Companion</h2>
+      <AgentChat onLog={onLog} />
+    </div>
+  );
+}

--- a/ui-kit-react/src/components/ScreenwritingUI.jsx
+++ b/ui-kit-react/src/components/ScreenwritingUI.jsx
@@ -1,0 +1,10 @@
+import AgentChat from './AgentChat';
+
+export default function ScreenwritingUI({ onLog }) {
+  return (
+    <div className="screenwriting-ui">
+      <h2>Screenwriting Assistant</h2>
+      <AgentChat onLog={onLog} />
+    </div>
+  );
+}

--- a/ui-kit-react/src/theme.css
+++ b/ui-kit-react/src/theme.css
@@ -72,3 +72,19 @@ body {
   overflow: auto;
   font-size: 0.8rem;
 }
+
+/* Custom UI section selector */
+.ui-select {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+/* Screenwriting and E-girl headings */
+.screenwriting-ui h2,
+.egirl-ui h2 {
+  margin-top: 0;
+}
+
+.egirl-ui h2 {
+  color: #db2777;
+}


### PR DESCRIPTION
## Summary
- add dedicated ScreenwritingUI and EgirlUI components
- allow switching between default, screenwriting, and e-girl modes
- style new UI sections

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5710853248327a698356686a0435a