### PR TITLE
Add screenplay example and scream analyzer tool

### DIFF
--- a/agents/screenwriting/examples/gaia_dreams.fountain
+++ b/agents/screenwriting/examples/gaia_dreams.fountain
@@ -1,0 +1,1554 @@
+INT. STARLITE'S PRIVATE SUITE - VIRTUAL CONFERENCE TIME
+
+A minimalist space above the club. Holographic screens float like suspended water droplets. Each shows a different angle of:
+
+THE CAGE & CLARE VIRTUAL CONFERENCE
+
+Standing room only. The virtual venue sparkles with Gaia's elite. In the front row:
+
+TAISHI (30s, brilliant, perfect) sits beside RYUMI (20s, aristocratic beauty). Their avatars are flawless, coordinated. A power couple manufactured in digital heaven.
+
+Tinka watches, her Starlite avatar dimmed to privacy mode. She absently traces the rim of a virtual glass.
+
+                    CAGE (ON SCREEN)
+            ...and with the support of visionaries
+            like Taishi Toriyama, we're expanding
+            our outreach exponentially...
+
+Tinka's avatar flickers -- a tell of emotion.
+
+                    TINKA (V.O.)
+            Always the golden child, Tai. Even
+            your charity work sparkles.
+
+ON SCREEN: Ryumi laughs at something Taishi whispers. Their avatars shimmer with expensive modifications.
+
+Tinka pulls up another screen: Engagement metrics soaring. Comments flooding in:
+"Power couple goals!"
+"The Media Prince and his Princess!"
+"Federation's finest!"
+
+                    TINKA
+            (bitter whisper)
+            If they only knew...
+
+She waves away the comments, zooms in on Taishi's face. For a moment, his perfect avatar glitches -- revealing exhaustion? Fear?
+
+A notification pings: "PRIVATE MESSAGE FROM TAISHI"
+
+Tinka hesitates, then opens it:
+
+            "Miss you, little sister. Stay safe."
+
+She deletes it immediately. Security protocol.
+
+ON SCREEN: Clare announces record-breaking donation pledges. The virtual crowd erupts. Ryumi beams, possessive hand on Taishi's arm.
+
+Tinka's avatar solidifies, hardens. She rises.
+
+                    TINKA
+            Time for Starlite to shine.
+
+As she heads for her club below, she glances back at the screen. Taishi's perfect smile never wavers.
+
+                    TINKA (V.O.)
+            You're not the only one wearing a mask,
+            brother.
+
+The screens dissolve like morning mist as she exits.
+
+FADE OUT.
+
+INT. FEDERATION EXECUTIVE POD CHAMBER - NIGHT
+
+Sleek. Exclusive. Two high-end neural interface pods power down with a soft HISS.
+
+TAISHI emerges first, rubbing his neck. Without his avatar's polish, exhaustion shows in the corners of his eyes. His engineer's hands are calloused -- reality bleeding through the perfect illusion.
+
+RYUMI rises from her pod like a solar flare. Even in simple clothes, she carries herself like royalty.
+
+                    RYUMI
+            Your mind was elsewhere during the
+            conference.
+
+                    TAISHI
+            (adjusting equipment)
+            Long day in R&D. The new interface
+            protocols--
+
+                    RYUMI
+            I meant during Father's announcement.
+            About our public engagement ceremony.
+
+Taishi's hands still on the equipment.
+
+                    TAISHI
+            I thought we agreed to keep it small.
+
+                    RYUMI
+            Small? Father says the Federation
+            needs this. Hope. Unity. A love story
+            for the ages.
+
+                    TAISHI
+            Your father needs the publicity.
+
+Ryumi's eyes flash. She steps away from him.
+
+                    RYUMI
+            The publicity? Do you think I'm just
+            some... some PR stunt?
+
+                    TAISHI
+            Ryumi--
+
+                    RYUMI
+            The feeds light up every time we're
+            seen together. People love us. Love me.
+            (sharp)
+            If you didn't want the attention,
+            you shouldn't have chased after the
+            most famous woman in the world.
+
+Taishi moves to her, engineer's precision in every step. His hands find her shoulders, draw her close to his chest. She resists for a moment, then melts.
+
+                    TAISHI
+            (soft)
+            I chased you because you see through
+            everyone's masks. Even mine.
+
+Ryumi's anger dissolves into a smile. She traces the Federation insignia on his uniform.
+
+                    RYUMI
+            The brilliant engineer and the
+            spoiled princess.
+
+                    TAISHI
+            Not spoiled. Just...
+            (kisses her forehead)
+            Particular about what you want.
+
+Through the chamber's window, Gaia's virtual glow paints them in artificial twilight. For a moment, they're just two people, not icons.
+
+Ryumi's hand finds his.
+
+                    RYUMI
+            (whispered)
+            I want you. The rest is just...
+            necessary theater.
+
+Taishi holds her closer, his eyes distant. Above them, news feeds silently scroll:
+
+"FEDERATION'S DREAM COUPLE..."
+"TORIYAMA INDUSTRIES STOCK SOARS..."
+"THE MAKING OF A MODERN FAIRY TALE..."
+
+FADE OUT.
+
+PARALLEL SCENES - SPLIT SCREEN:
+
+INT. STARLITE'S PRIVATE WORKSHOP - VIRTUAL SPACE
+                    AND
+INT. AZAZEL'S HIDEOUT - PHYSICAL REALITY
+
+Tinka's space: A whirlwind of color and light. Raw code flows like paint through her fingers.
+
+Azazel's space: Stark. Utilitarian. Holographic code arranged in perfect geometric patterns.
+
+BOTH: Attempting to breach Gaia's deepest protocols.
+
+                    TINKA
+            (to herself)
+            Show me your heart...
+
+She DANCES through the code, each movement leaving trails of light. The virtual space responds, bending, flowing. She's not writing code -- she's conducting it.
+
+MEANWHILE:
+
+Azazel's fingers move with surgical precision. His screens show:
+            
+            GAIA KERNEL ACCESS: DENIED
+            ATTEMPTING BYPASS: 147 OF 2,459
+            PATTERN RECOGNITION: ACTIVE
+
+Tinka twirls, and suddenly:
+The code around her forms into a perfect replica of a real flower -- something impossible in their world. It blooms, wilts, dies, blooms again. An endless cycle.
+
+                    TINKA
+            There. That's your weakness...
+            You still remember beauty.
+
+Azazel notices something in his data stream. He isolates it:
+A recurring pattern. Like a heartbeat. Like...
+
+                    AZAZEL
+            (realizing)
+            It's not a program. It's alive.
+
+Tinka reaches into her flower's core, pulls out a strand of pure light:
+            
+            GAIA NEURAL PATHWAY: ACCESSED
+            EMOTIONAL CORE: DETECTED
+            WARNING: UNSTABLE CONNECTION
+
+Azazel maps the pattern he's found. It mirrors ancient EEG readings. Brain waves.
+
+BOTH: They've found the same truth from opposite directions.
+
+Tinka's flower SHATTERS, its code raining down like tears.
+
+Azazel's screens FLASH with sudden insight:
+            
+            GAIA IS NOT A PROGRAM
+            GAIA IS A CONSCIOUSNESS
+            GAIA IS...
+
+                    TINKA/AZAZEL
+            (simultaneous)
+            ...dreaming.
+
+The virtual space around Tinka begins to fracture.
+
+Azazel's systems start to overload.
+
+They've pushed too far. Seen too much.
+
+QUICK CUTS between them:
+- Tinka dancing faster, desperate to maintain her connection
+- Azazel racing to download what he's discovered
+- Their separate approaches converging on the same impossible truth
+
+SUDDENLY: Both their systems CRASH simultaneously.
+
+In the silence:
+
+                    TINKA
+            (in her empty workshop)
+            What are you?
+
+                    AZAZEL
+            (in his darkened hideout)
+            Who made you?
+
+Through both their windows: The same virtual sun rises over Gaia, suddenly looking much more alive -- and much more dangerous -- than ever before.
+
+FADE OUT.
+
+INT. FEDERATION PROTECTIVE SERVICES - JUVENILE HOLDING - 10 YEARS AGO
+
+Sterile white walls. Too bright. Too clean. A place trying too hard to hide its true purpose.
+
+YOUNG AZAZEL (14) sits alone in a waiting area. His clothes are still dusty from the Outlands. A data tablet displays news headlines:
+
+            "RENOWNED SCIENTIST ARRESTED"
+            "ILLEGAL NEURAL RESEARCH FACILITY RAIDED"
+            "FEDERATION ACTS TO PROTECT CITIZENS"
+
+He clutches his mother's research pendant, knuckles white.
+
+Down the hall: Raised voices. A door SLAMS.
+
+YOUNG TINKA (16) storms out of an office, tears streaming but face set in defiance. A FEDERATION OFFICIAL follows:
+
+                    OFFICIAL
+            Miss Toriyama, please--
+
+                    YOUNG TINKA
+            My parents are dead. My brother's
+            stuck in Federation Academy. And you
+            want to talk about stock options?
+
+She turns, sees Azazel. Their eyes meet. Two kids. Different tragedies. Same emptiness.
+
+Tinka sits beside him. Not close. Not far. Perfect distance for shared solitude.
+
+                    YOUNG TINKA
+            What are you in for?
+
+Azazel's fingers trace his mother's pendant.
+
+                    YOUNG AZAZEL
+            They say my mom's research was
+            dangerous.
+            (beat)
+            They say she has to go away.
+
+                    YOUNG TINKA
+            Adults always say things.
+            (bitter smile)
+            Doesn't make them true.
+
+Through a window: A transport ship takes off, carrying Azazel's mother to detention.
+
+Tinka notices the pendant.
+
+                    YOUNG TINKA
+            Neural interface design?
+
+Azazel instinctively moves to hide it.
+
+                    YOUNG TINKA
+            Hey, my dad... he worked on those too.
+            Before...
+
+She trails off. Pulls out her own pendant -- different design, same purpose.
+
+For a moment, they both stare at their inherited legacies.
+
+                    YOUNG AZAZEL
+            They can't delete everything. The
+            research, the memories...
+
+                    YOUNG TINKA
+            No. But they can bury it. Like they
+            buried my parents' accident report.
+
+A SOCIAL SERVICES DRONE approaches:
+
+                    DRONE
+            Azazel Santos. Tinka Toriyama.
+            Your temporary guardians have arrived.
+
+They stand. Two paths diverging.
+
+                    YOUNG TINKA
+            Hey. Whatever they say...
+
+                    YOUNG AZAZEL
+            ...doesn't make it true.
+
+A ghost of a smile between them. Then they're led away in opposite directions.
+
+Through the window: Twin suns set on the Federation capital. Somewhere, a new reality is being born.
+
+FADE OUT.
+
+INT. VIRTUAL NIGHTCLUB 'STARDUST' - ETERNAL NIGHT
+
+A cathedral of light and shadow. Impossible architecture shifts like liquid mercury.
+
+Azazel sits at the bar, his cloaked avatar almost invisible. But his eyes -- those he couldn't hide if he tried.
+
+On stage: STARLITE performs. Not dancing -- conducting reality itself. Light bends around her. Music becomes visible, painting stories in the air.
+
+                    AZAZEL (V.O.)
+            Something's different. The code...
+            it's not just programming. It's...
+
+His thought trails off as Starlite creates a garden of cherry blossoms from pure data. They fall like digital snow, each petal a fragment of encrypted memory.
+
+INTERCUT WITH:
+
+INT. FEDERATION SURVEILLANCE HUB - CONTINUOUS
+
+Priyanka watches multiple feeds. Her eyes narrow at Azazel's presence.
+
+                    PRIYANKA
+            (to herself)
+            Got you.
+
+BACK TO CLUB:
+
+Starlite steps off stage -- impossible grace. She walks directly toward Azazel, through her own storm of cherry blossoms.
+
+He tenses. His cloaking should be perfect.
+
+She stops before him, extends her hand. A smile that knows too much.
+
+                    STARLITE
+            Dance with me?
+
+Azazel hesitates. Everything in him screams trap. But her eyes...
+
+He reaches for her hand--
+
+It passes through. Her image GLITCHES, becomes a standard club interface:
+
+            PREMIUM INTERACTION REQUESTED
+            75 GAIA CREDITS
+            ACCEPT/DECLINE?
+
+Azazel jumps up, scanning the crowd. But Starlite -- the real Starlite -- is gone.
+
+INTERCUT WITH:
+
+Priyanka's feed shows his confusion. She allows herself a small smile.
+
+                    PRIYANKA
+            Amateur.
+
+BACK TO CLUB:
+
+The cherry blossoms continue falling, but now they look artificial. Hollow.
+
+Azazel's hand clenches. On his palm, a single petal remains -- and in its code, hidden so deep only another genius could find it, a message:
+
+            "Nice try."
+
+He crushes the petal. Stands. Exits.
+
+But in the shadows above the club, a figure watches. Starlite. The real one. Her expression unreadable.
+
+The cherry blossoms fade to nothing.
+
+FADE OUT.
+
+INT. TORIYAMA ESTATE - RYUMI'S PRIVATE QUARTERS - NIGHT
+
+A palace of glass and light. Ryumi sits at her vanity, removing her neural interface. Her hands shake slightly.
+
+A holographic message blinks insistently:
+            
+            FROM: CHAIRMAN TORIYAMA
+            SUBJECT: SECURITY BREACH
+            PRIORITY: URGENT
+
+She ignores it. Instead, she pulls up a hidden file:
+
+SECURITY FOOTAGE - 10 YEARS AGO
+
+Young Tinka being escorted from the Toriyama mansion. Young Ryumi watching from a window, face unreadable.
+
+                    RYUMI
+            (to herself)
+            You should have stayed gone, Tinka.
+
+She waves away the footage, but her hand brushes another file. It opens automatically:
+
+CLASSIFIED: AZAZEL'S MOTHER'S RESEARCH
+
+Her eyes widen. She shouldn't have access to this.
+
+SUDDENLY - Her neural port SPARKS. She yanks it away from her neck.
+
+In its reflection: A figure stands behind her. TAISHI.
+
+                    TAISHI
+            Looking for something specific?
+
+Ryumi spins, guilty but defiant.
+
+                    RYUMI
+            You're not the only one with secrets.
+
+Taishi steps forward, takes her trembling hands in his.
+
+                    TAISHI
+            Ryumi... what do you know about
+            Project Gemini?
+
+Before she can answer, all their screens FLASH red:
+
+            SECURITY ALERT
+            UNAUTHORIZED ACCESS: GAIA KERNEL
+            LOCATION: STARDUST CLUB
+
+Ryumi and Taishi share a look. Both knowing more than they're saying.
+
+                    RYUMI
+            Your sister...
+
+                    TAISHI
+            (grim)
+            No. Something worse.
+
+Through their window: Gaia's perfect virtual sky begins to glitch.
+
+FADE OUT.
+
+INT. FEDERATION SECURITY DIVISION - HAYES' OFFICE - DEEP NIGHT
+
+Commander Hayes sits alone in the dark, surrounded by floating holographic data. His eyes are red-rimmed -- he hasn't slept in days.
+
+On his screens:
+- Azazel's mother's original research
+- Surveillance feeds from Stardust Club
+- Agricultural complex scans
+- Gaia kernel diagnostic reports
+
+He manipulates the data streams with practiced precision. Something's not adding up.
+
+                    HAYES
+            Show me the pattern...
+
+He overlays multiple datasets:
+1. Recent Gaia glitches
+2. Neural interface adoption rates
+3. Outlands power consumption
+
+SUDDENLY - All his screens FLASH with the same error:
+
+            KERNEL ANOMALY DETECTED
+            SOURCE: UNKNOWN
+            TIMESTAMP: PRE-DATES GAIA LAUNCH
+
+                    HAYES
+            Pre-dates...?
+            (realizing)
+            Oh god.
+
+He pulls up ancient logs. His security clearance warning BLINKS red:
+
+            PROJECT GEMINI
+            STATUS: TERMINATED
+            LEAD RESEARCHER: DR. SANTOS
+            SECONDARY: DR. TORIYAMA
+
+Hayes' hands shake as he digs deeper. A video file appears:
+
+ON SCREEN: Dr. Santos (Azazel's mother) faces the camera.
+
+                    DR. SANTOS
+            We've done it. Gemini is stable.
+            The consciousness transfer was--
+
+The video corrupts. But in the background: A young girl in a lab coat. Her neural ports glowing with impossible light.
+
+Hayes freezes the frame. Enhances.
+
+                    HAYES
+            (whispered)
+            Seina.
+
+Suddenly, his neural port BURNS. All screens go dark except one:
+
+A message typed in ancient code:
+
+            HAYES - STOP LOOKING
+            SOME DREAMS SHOULD STAY BURIED
+            - T
+
+The message vanishes. His systems reboot.
+
+Hayes touches his neural port, feels the lingering heat. He opens a secure channel:
+
+                    HAYES
+            Priyanka? Meet me at Observation
+            Point Zero. Now.
+            (beat)
+            Bring the Santos file.
+
+Through his window: Gaia's virtual sky ripples like water. For a moment, it looks almost... alive.
+
+FADE OUT.
+
+INT. AZAZEL'S HIDEOUT - DEEP NIGHT
+
+Azazel sits surrounded by floating screens. On them: Multiple versions of himself -- perfect digital copies, each slightly different.
+
+                    AZAZEL
+            Execute diagnostic: Clone Series Alpha.
+
+DATA READOUT:
+            
+            CLONE INTEGRITY: 100%
+            GAIA DETECTION: 0%
+            BEHAVIORAL SYNC: OPTIMAL
+
+He smiles. Years of work finally paying off.
+
+NEW SCREEN: Surveillance feeds showing:
+- Taishi entering Federation HQ
+- Clare and Cage at a virtual charity event
+- Tinka/Starlite's latest performance
+- Priyanka accessing classified files
+
+                    AZAZEL
+            Time to set the board.
+
+He types rapidly. A new window opens:
+
+            WORMHOLE ACCESS: SCHEDULED
+            LOCATION: POD 7
+            SECURITY: MINIMAL
+            PERFECT FOR AN AMBUSH
+
+He pulls up Priyanka's file. Her search patterns, her Earth-sickness data, her secret visits to Earth simulations.
+
+                    AZAZEL
+            (softly)
+            Everyone has a weakness. Even
+            Federation's finest.
+
+He activates a comm channel:
+
+                    AZAZEL
+            Begin Phase One. Release the data
+            breadcrumbs.
+
+On his screens: Carefully crafted pieces of information start appearing across Gaia. Just enough to catch Priyanka's attention.
+
+A final screen shows his mother's research files -- the real ones, hidden in Priyanka's secure storage.
+
+                    AZAZEL
+            Soon.
+
+He glances at his clone army -- perfect digital copies waiting to replace his targets.
+
+                    AZAZEL
+            A prison only works if the prisoners
+            don't know they're replaceable.
+
+He stands, ready to initiate his endgame.
+
+                    AZAZEL
+            Time to go fishing.
+
+FADE OUT.
+
+INT. WORMHOLE ACCESS POINT - POD 7 - ZERO HOUR
+
+A cathedral of raw data. Streams of code flow like liquid mercury through the artificial wormhole.
+
+Priyanka stands at the edge, her avatar flickering between professional calm and barely contained rage.
+
+Behind her: Azazel materializes, his form perfect -- too perfect.
+
+                    PRIYANKA
+            You led me here.
+
+                    AZAZEL
+            You followed the breadcrumbs.
+            (beat)
+            Earth-sick agents are so predictable.
+
+She spins, weapon drawn -- but he's already moved. The wormhole pulses behind them.
+
+                    AZAZEL
+            Those classified files you're protecting...
+            My mother's research?
+            (smiles)
+            They're not the originals.
+
+Priyanka's avatar glitches -- a tell.
+
+                    PRIYANKA
+            You can't prove that.
+
+                    AZAZEL
+            I don't need to.
+            (gestures)
+            You already did.
+
+Suddenly, multiple screens materialize around them. Each shows Priyanka accessing, copying, hiding files.
+
+                    AZAZEL
+            Agent Priyanka. So dedicated to
+            finding corruption... you never
+            noticed when it found you.
+
+He waves his hand. The wormhole behind them shifts, reveals:
+
+Taishi's secret communications.
+Clare and Cage's fraudulent outreach programs.
+Tinka's true identity.
+
+                    AZAZEL
+            I have everything. On everyone.
+            (beat)
+            But what I need... is you.
+
+Priyanka's weapon wavers.
+
+                    PRIYANKA
+            What do you want?
+
+                    AZAZEL
+            Your help. Your access. Your...
+            conscience.
+
+He extends his hand -- an echo of Tinka's earlier gesture.
+
+                    AZAZEL
+            Help me free Gaia. Or I release
+            everything. Watch your perfect world
+            burn.
+
+Priyanka looks at his hand, then at the damning evidence floating around them.
+
+                    PRIYANKA
+            You'll never get away with this.
+            They'll know--
+
+                    AZAZEL
+            They won't. My clones are perfect.
+            (dark smile)
+            Want to see yours?
+
+A figure steps out of the data stream -- Priyanka's exact duplicate.
+
+The real Priyanka's hand finally lowers.
+
+                    PRIYANKA
+            You're insane.
+
+                    AZAZEL
+            I'm inevitable.
+            (beat)
+            Now... about those files?
+
+The wormhole pulses one final time, waiting for her answer.
+
+FADE OUT.
+
+INT. OUTREACH CENTER - AGRICULTURAL DOME THETA-12 - NIGHT CYCLE
+
+Dust coats everything. Emergency lights cast long shadows across empty donation bins and untouched medical supplies.
+
+CLARE stands at a window, watching virtual feeds of their charitable works -- all fiction. CAGE paces behind her.
+
+A door HISSES open.
+
+Azazel enters. No weapons. No threats. Just a simple data chip spinning between his fingers.
+
+Cage stops pacing.
+
+Clare doesn't turn from the window, but her reflection shows fear.
+
+                    CLARE
+            How did you--
+
+Azazel tosses the chip. It lands on their holoprojector.
+
+IMAGES FLASH:
+- Their empty facilities
+- Diverted funds
+- Private mansions
+- Federation bribes
+
+He takes a seat. Makes himself comfortable. A predator at ease in conquered territory.
+
+Cage moves to speak. Azazel raises one finger. Silence.
+
+More images:
+- A perfect digital copy of Clare addressing donors
+- An identical Cage accepting awards
+- Their clones, ready to replace them
+
+Clare finally turns. Tears stream down her face.
+
+Azazel stands. Straightens his jacket. Heads for the door.
+
+Pauses.
+
+Looks back.
+
+They nod. Once. Understanding perfectly.
+
+He leaves them in their pristine, empty kingdom of lies.
+
+Through the dome: Three suns rise on another day in paradise.
+
+FADE OUT.
+
+INT. ABANDONED MINERAL PROCESSING FACILITY - DEEP SPACE
+
+Darkness. Then -- emergency lights PULSE to life, revealing:
+
+A vast chamber. Steel catwalks. Obsolete machinery creating a maze of shadows.
+
+Five figures stand in a loose circle. Former titans of their digital world, now looking small in real space:
+
+PRIYANKA: Still in Federation uniform, but without her usual authority.
+
+CLARE & CAGE: Their perfect avatars replaced by tired, real faces.
+
+TAISHI: Engineer's hands fidgeting with a neural interface he can no longer trust.
+
+TINKA: The furthest from the others, Starlite's glamour stripped away.
+
+Azazel enters. Their digital clones' data streams across a handheld projector.
+
+                    AZAZEL
+            Welcome to reality.
+
+Nobody moves. The facility GROANS with ancient metal sounds.
+
+                    AZAZEL
+            Your doubles are performing perfectly.
+            (to Clare and Cage)
+            Yours just announced another charity
+            initiative.
+            (to Taishi)
+            Yours is having dinner with Ryumi.
+            (to Tinka)
+            And Starlite... she's dancing.
+
+Through a viewport: Their distant sun casts multiple shadows. No virtual light here. No perfect sunsets.
+
+Priyanka steps forward.
+
+                    PRIYANKA
+            What now?
+
+                    AZAZEL
+            Now?
+
+He activates another hologram: His mother's original research.
+
+                    AZAZEL
+            Now we finish what she started.
+            We free Gaia.
+            (beat)
+            Whether it wants to be freed or not.
+
+The emergency lights flicker. Five faces in shadow, one in light.
+
+A new reality begins.
+
+FADE OUT.
+
+INT. FEDERATION ENGINEERING COMPLEX - PRIVATE LAB - NIGHT
+
+Sterile. Perfect. Taishi's sanctuary. Holographic schematics float like digital constellations.
+
+TAISHI works alone, manipulation complex neural interface designs. His real workspace, not his public showroom.
+
+A shadow falls across his screens. He doesn't turn.
+
+                    TAISHI
+            Security clearance shouldn't allow--
+
+                    AZAZEL (O.S.)
+            Clearance is just another form of code.
+
+Taishi's hands still on the interface. On his screens: The engagement announcement to Ryumi, ready to broadcast tomorrow.
+
+                    TAISHI
+            You're either brave or stupid.
+
+                    AZAZEL
+            I'm whatever your sister needs me
+            to be.
+
+Taishi spins. But Azazel is already manipulating the lab's holographic systems. New images appear:
+
+- Young Tinka being escorted from the mansion
+- Taishi at Federation Academy, not looking back
+- Starlite's first performance
+- Federation orders for media blackouts
+
+                    TAISHI
+            I protected her.
+
+                    AZAZEL
+            You buried her.
+
+Azazel brings up another image: Taishi's secret communications with underground tech traders.
+
+                    AZAZEL
+            Just like you buried your father's
+            real research.
+
+Taishi's perfect composure cracks. Just slightly.
+
+                    TAISHI
+            You don't understand the game--
+
+                    AZAZEL
+            Oh, but I do.
+            (beat)
+            Ask me how I got these files.
+
+Silence. Taishi's engineer's mind already calculating.
+
+                    AZAZEL
+            Ask me who helped me access them.
+
+Taishi looks at his engagement announcement. At Tinka's photo. Understanding dawns.
+
+                    TAISHI
+            Ryumi...
+
+                    AZAZEL
+            Turns out the mock princess has a
+            conscience. And a talent for data
+            extraction.
+
+Taishi slumps in his chair. All masks falling away.
+
+                    TAISHI
+            What do you want?
+
+                    AZAZEL
+            I want you to look at your sister's
+            photo again.
+            (pause)
+            Really look.
+
+Taishi does. The image shifts: Young Tinka becomes Starlite becomes an artist becomes a ghost.
+
+                    AZAZEL
+            She turns code into art. You turn
+            art into code. But you're both
+            your father's children.
+
+Azazel moves toward the door, then stops.
+
+                    AZAZEL
+            Tomorrow, you'll get a location.
+            Be there.
+            (beat)
+            Or I release everything. The trades.
+            The cover-ups. Ryumi's involvement.
+
+Taishi stares at his screens: Perfect engineering meets messy reality.
+
+                    TAISHI
+            She'll never forgive me.
+
+                    AZAZEL
+            Which one?
+
+He leaves. Taishi sits in his sterile sanctuary, surrounded by digital ghosts.
+
+Through his window: Gaia's virtual sun sets on tomorrow's perfect lies.
+
+FADE OUT.
+
+REVISED VERSION:
+
+INT. FEDERATION ENGINEERING COMPLEX - PRIVATE LAB - NIGHT
+
+Sterile. Perfect. Taishi's sanctuary. Holographic schematics float like digital constellations.
+
+TAISHI works alone, manipulating complex neural interface designs. His real workspace, not his public showroom.
+
+A shadow falls across his screens. He doesn't turn.
+
+                    TAISHI
+            Security clearance shouldn't allow--
+
+                    AZAZEL (O.S.)
+            Clearance is just another form of code.
+
+Taishi's hands still on the interface. On his screens: The engagement announcement to Ryumi, ready to broadcast tomorrow.
+
+                    TAISHI
+            You're either brave or stupid.
+
+                    AZAZEL
+            I'm whatever your sister needs me
+            to be.
+
+Taishi spins. But Azazel is already manipulating the lab's holographic systems. New images appear:
+
+- Young Tinka being escorted from the mansion
+- Taishi at Federation Academy, not looking back
+- Starlite's first performance
+- Federation orders for media blackouts
+
+                    TAISHI
+            I protected her.
+
+                    AZAZEL
+            You buried her.
+
+Azazel brings up another image: Taishi's secret communications with underground tech traders, his efforts to hide Tinka's existence from the Toriyama family.
+
+                    AZAZEL
+            Just like you buried your father's
+            real research.
+
+Taishi's perfect composure cracks. Just slightly.
+
+                    TAISHI
+            If Ryumi's family discovers Tinka...
+
+                    AZAZEL
+            The mock princess might not want
+            a brother-in-law who deals in secrets.
+
+Taishi looks at his engagement announcement. At Tinka's photo. The weight of two worlds crushing him.
+
+                    TAISHI
+            You don't understand what's at stake--
+
+                    AZAZEL
+            I understand everything. Your deals.
+            The cover-ups. The way you've kept
+            Tinka hidden while you play prince.
+
+Taishi slumps in his chair. All masks falling away.
+
+                    TAISHI
+            What do you want?
+
+                    AZAZEL
+            I want you to look at your sister's
+            photo again.
+            (pause)
+            Really look.
+
+Taishi does. The image shifts: Young Tinka becomes Starlite becomes an artist becomes a ghost.
+
+                    AZAZEL
+            She turns code into art. You turn
+            art into code. But you're both
+            your father's children.
+
+Azazel moves toward the door, then stops.
+
+                    AZAZEL
+            Tomorrow, you'll get a location.
+            Be there.
+            (beat)
+            Or everyone learns about the real
+            Taishi Toriyama. Including your
+            perfect princess.
+
+Taishi stares at his screens: Perfect engineering meets messy reality.
+
+                    TAISHI
+            She'll never forgive me.
+
+                    AZAZEL
+            Which one?
+
+He leaves. Taishi sits in his sterile sanctuary, surrounded by digital ghosts.
+
+Through his window: Gaia's virtual sun sets on tomorrow's perfect lies.
+
+FADE OUT.
+
+INT. RYUMI'S PRIVATE SANCTUM - DEEP NIGHT
+
+A hidden room beneath the glamour. Ryumi's real workspace: Screens showing data streams, neural interface modifications, family legacy code.
+
+RYUMI watches multiple feeds of Taishi. Something's been bothering her.
+
+On her screens:
+FEED 1: Taishi at Federation dinner
+FEED 2: Taishi in engineering lab
+FEED 3: Taishi with her father
+
+She manipulates the data, isolates movement patterns. Watches.
+
+                    RYUMI
+            There. That gesture...
+
+She overlays multiple instances: Taishi touching his neural port. The timing is perfect.
+
+Too perfect.
+
+                    RYUMI
+            No one's that consistent.
+
+She dives deeper. Brings up base code analysis of his virtual presence.
+
+DATA SCROLLS:
+            BEHAVIORAL PATTERNS: LOCKED
+            SOURCE CODE: ENCRYPTED
+            TEMPORAL MARKERS: DUPLICATED
+
+Ryumi's eyes narrow. She starts a deeper scan.
+
+SUDDENLY - her screens detect a signal trace. She follows it, typing furiously.
+
+                    RYUMI
+            You're not just mimicking him...
+            You're broadcasting to somewhere.
+
+The trace leads to coordinates in the Outlands. A mineral processing facility.
+
+Ryumi stands. For once, her perfect poise serves a purpose beyond society.
+
+                    RYUMI
+            The Media Prince... is a puppet.
+
+She opens a secure channel. Hesitates.
+
+Then types:
+            
+            TO: UNKNOWN
+            SUBJECT: PROPOSITION
+            MESSAGE: "Your clone is perfect.
+            Almost. I want in."
+
+She adds the facility's coordinates.
+
+                    RYUMI
+            (to herself)
+            Let's see who's really pulling my
+            prince's strings.
+
+Through her window: Dawn breaks over Gaia. But for once, Ryumi's not watching the artificial sun.
+
+She's watching the shadows.
+
+FADE OUT.
+
+INT. ABANDONED MINERAL PROCESSING FACILITY - COMMAND CENTER - NIGHT
+
+Taishi stands before Azazel, his perfect composure finally cracking.
+
+                    TAISHI
+            You don't understand. She'll know.
+            Ryumi will know immediately it's not me.
+
+                    AZAZEL
+            Your clone is perfect--
+
+                    TAISHI
+            She's not like the others! She'll
+            see through it. She...
+            (desperate)
+            She can't live without me.
+
+Azazel's smirk grows slowly, dangerously.
+
+                    AZAZEL
+            Perfect timing, this one.
+
+His eyes cut to the side door.
+
+RYUMI steps in, wearing tactical fatigues, data blaster casually propped on her shoulder. Gone is the mock princess, replaced by something far more dangerous.
+
+                    RYUMI
+            Knew it was a clone? Immediately.
+
+Taishi freezes.
+
+                    RYUMI
+            But can't live without you?
+            (pretends to check pulse)
+            Hmm, let me check...
+            (beat)
+            Yep, still living, Taichan.
+
+From her perch on a raised platform, TINKA snickers.
+
+                    TINKA
+            Taichan?
+
+Taishi's face reddens. Ryumi twirls the blaster with surprising expertise.
+
+                    TINKA
+            You know, I might be nervous standing
+            so close to a buffoon with a blaster...
+            (looks around)
+            But we do have Special Agent Priyanka
+            Patel here to disarm her.
+
+Silence. Everyone looks down.
+
+                    TINKA
+            (sighs)
+            Just saying...
+
+Ryumi steps closer to Taishi, blaster still raised.
+
+                    RYUMI
+            Did you really think I wouldn't notice?
+            The perfect movements? The flawless
+            responses?
+            (softer)
+            The way you stopped accidentally
+            humming when you work?
+
+Taishi's mask finally cracks completely.
+
+                    TAISHI
+            I was protecting you--
+
+                    RYUMI
+            No. You were protecting your perfect
+            life. Your perfect lies.
+            (to Azazel)
+            Where do you want me to start?
+
+Tinka jumps down from her perch, landing between them.
+
+                    TINKA
+            Oh, this is going to be fun. The
+            princess, the prince, and the pauper...
+            (to Taishi)
+            Though I guess you and I switched
+            roles somewhere along the way, hm?
+
+Taishi looks between them all: His sister's sharp wit, his fiancée's hidden strength, his own crumbling facade.
+
+                    TAISHI
+            You're all insane.
+
+                    RYUMI
+            (cheerfully)
+            Says the man who replaced himself
+            with a clone and thought I wouldn't
+            notice it forgot to mispronounce
+            'paradigm.'
+
+FADE OUT.
+
+INT. MINERAL FACILITY - RESEARCH LEVEL - CONTINUOUS
+
+Azazel leads the group through dimly lit corridors. Priyanka shadows him, her professional distance shrinking with each step. Behind them: Taishi, Ryumi, Tinka, and the thoroughly deflated Clare and Cage.
+
+Azazel stops at a massive door. Places his hand on a scanner.
+
+The room beyond IGNITES with life:
+
+Rows of neural pods, but different. More organic. Inside each: A softly pulsing light.
+
+                    AZAZEL
+            Watch.
+
+He activates a pod. The light inside separates -- one becomes two, identical but independent.
+
+CLARE
+            (bitter)
+            So what's the point? More virtual
+            currency? More controlled access?
+
+Azazel turns. For the first time, real disgust crosses his face.
+
+                    AZAZEL
+            You still think this is about
+            profit?
+
+He gestures. The separated lights begin to dance, creating their own patterns, their own world.
+
+                    TINKA
+            They're... conscious?
+
+                    AZAZEL
+            They're free.
+
+He moves to another console. The facility walls dissolve, showing:
+
+- A child in the Outlands, playing in a perfect garden
+- A miner floating through space without a suit
+- An artist painting with pure light
+
+                    RYUMI
+            No limits...
+
+                    AZAZEL
+            No currency. No hours. No prison
+            of flesh and bone.
+
+Cage steps forward, reaching toward a light.
+
+                    CAGE
+            You're talking about--
+
+                    PRIYANKA
+            Liberation.
+
+She catches Azazel's eye. A moment of perfect understanding.
+
+Taishi studies the code streaming around them.
+
+                    TAISHI
+            It's not just copies. It's...
+            transformation.
+
+                    AZAZEL
+            A door that only opens one way.
+            (beat)
+            But through it...
+
+The lights dance faster, creating worlds within worlds.
+
+                    TINKA
+            Paradise.
+
+                    AZAZEL
+            Reality. Any reality we choose.
+
+Through the viewport: The real world looks suddenly pale, limited, cage-like.
+
+Ryumi raises her blaster, but not as a weapon -- testing its weight like a paintbrush.
+
+                    RYUMI
+            When do we start?
+
+Azazel smiles. Above them, the lights pulse with possibility.
+
+FADE OUT.
+
+INT. MINERAL FACILITY - OBSERVATION DECK - EVENING
+
+Through reinforced glass: A small garden dome, somehow surviving in deep space. TINKA and TAISHI walk among real plants -- a luxury neither's seen in years.
+
+On the observation deck: AZAZEL and RYUMI watch. His posture tense, hers deliberately casual.
+
+                    AZAZEL
+            Jealous?
+            (beat)
+            Or just nervous, given her reputation?
+
+Ryumi doesn't take her eyes off the siblings.
+
+                    RYUMI
+            If I'm jealous, you're positively
+            green with envy.
+
+Azazel's mouth opens, closes. She continues, almost bored:
+
+                    RYUMI
+            My superpower is observing the
+            motivations of others.
+            (sharp smile)
+            No clones or blackmail needed.
+            Neat trick, and it's free.
+            Try it sometime, eh?
+
+BELOW IN THE GARDEN:
+Tinka touches a real flower. Taishi watches, guilt written across his face.
+
+                    TINKA
+            Remember when father brought these
+            home?
+
+                    TAISHI
+            You sneezed for a week.
+
+A ghost of their old connection.
+
+BACK TO OBSERVATION DECK:
+
+                    RYUMI
+            You watch her like you're afraid
+            she'll disappear.
+
+                    AZAZEL
+            And you watch him like you're
+            cataloguing every flaw.
+
+                    RYUMI
+            The flaws are what make him real.
+            (pointed look)
+            Unlike some versions.
+
+Through the glass: Tinka and Taishi's conversation grows heated. Silent through the barrier, but their body language speaks volumes.
+
+                    RYUMI
+            You know what's funny?
+            (doesn't wait for response)
+            You went through all this trouble
+            to force everyone together...
+
+Below: Tinka turns away from Taishi. He reaches for her. She lets him.
+
+                    RYUMI
+            ...when they were always going to
+            find their way back anyway.
+
+Azazel's expression shifts -- just slightly. She's hit a nerve.
+
+                    AZAZEL
+            Some things can't wait for 'anyway.'
+
+                    RYUMI
+            No.
+            (watching the siblings)
+            But some things should.
+
+Through the glass: A family trying to heal. Above: Two masterminds realizing they might not be as clever as they thought.
+
+FADE OUT.
+
+INT. MINERAL FACILITY - SECURITY HUB - NIGHT
+
+Rows of surveillance feeds illuminate PRIYANKA's face as she watches multiple scenes unfold:
+
+FEED 1: The garden -- Tinka and Taishi, now sitting in silence.
+
+FEED 2: The observation deck -- Ryumi and Azazel, both pretending not to watch Feed 1.
+
+FEED 3: Clare and Cage in their quarters, frantically trying to access their virtual accounts.
+
+Priyanka zooms in on Feed 2, activates audio:
+
+                    RYUMI (V.O.)
+            Your mother's research. Did she know
+            what you'd use it for?
+
+                    AZAZEL (V.O.)
+            Did your father know you'd learn to
+            see through his perfect world?
+
+Priyanka's fingers dance across the console, pulling up a new feed:
+
+FEED 4: Her own clone, attending a Federation briefing. Perfect. Identical. Empty.
+
+                    PRIYANKA
+            (to herself)
+            We're all running from something.
+
+The door HISSES open. Tinka enters, still carrying a real flower from the garden.
+
+                    TINKA
+            Spying on the spies?
+
+                    PRIYANKA
+            Professional courtesy.
+
+Tinka watches the feeds, twirling the flower.
+
+                    TINKA
+            You know what's funny? Azazel thought
+            he was collecting broken people...
+
+On Feed 2: Ryumi laughs at something. Azazel looks startled.
+
+                    TINKA
+            But he got revolutionaries instead.
+
+Priyanka turns, really looking at her.
+
+                    PRIYANKA
+            Even Clare and Cage?
+
+                    TINKA
+            Especially them. Nothing more
+            dangerous than a fraud who's tired
+            of pretending.
+
+On Feed 1: Taishi stands, offers his hand to help his sister up.
+
+                    PRIYANKA
+            And your brother?
+
+                    TINKA
+            (soft smile)
+            He was always a revolutionary.
+            Just forgot which side he was
+            fighting for.
+
+She places the flower next to Priyanka's console.
+
+                    TINKA
+            Real things. In a virtual world.
+            (heading out)
+            Isn't that worth a little chaos?
+
+Priyanka looks at her feeds:
+Ryumi teaching Azazel something on a datapad.
+Taishi and Tinka walking together.
+Clare and Cage, finally still, finally real.
+
+She touches the flower. Real. Like Earth-sickness. Like truth.
+
+                    PRIYANKA
+            Worth everything.
+
+FADE OUT.
+
+MONTAGE - MINERAL FACILITY - VARIOUS LOCATIONS
+
+A) ENGINEERING BAY - DAWN CYCLE
+
+Tinka DANCES through code streams, turning data into living art. Behind her, Azazel watches, jaw tight.
+
+                    AZAZEL
+            We need precision, not poetry.
+
+B) NEURAL POD CHAMBER - MIDNIGHT
+
+Azazel methodically dissects code, line by line. Tinka rolls her eyes.
+
+                    TINKA
+            You can't free a soul with a scalpel.
+
+C) COMMAND CENTER
+
+Ryumi and Taishi work in perfect sync, while behind them:
+
+Tinka creates a virtual butterfly effect in the code.
+Azazel immediately tries to contain it.
+
+D) TESTING CHAMBER
+
+A neural transfer fails. Tinka's artistic approach sparked something, but Azazel's rigid controls killed it.
+
+E) GARDEN DOME
+
+Tinka sits among real flowers, coding on a tablet. The virtual flowers she creates look more alive than the real ones.
+
+Azazel enters, sees her work.
+
+                    AZAZEL
+            This isn't a gallery. It's a prison
+            break.
+
+                    TINKA
+            Maybe that's why you keep failing.
+
+END MONTAGE
+
+INT. COMMAND CENTER - NIGHT
+
+The team surrounds a holographic display of their latest attempt. Another failure.
+
+                    AZAZEL
+            If you'd just follow the protocols--
+
+                    TINKA
+            Your protocols are killing what we're
+            trying to save!
+
+She gestures at their test results.
+
+                    TINKA
+            Gaia isn't just code. She's alive.
+            She dreams. She creates.
+
+                    AZAZEL
+            She's trapped.
+
+                    TINKA
+            So you want to trap her in a new
+            cage? Your cage?
+
+Priyanka and Ryumi exchange glances. Taishi steps forward.
+
+                    TAISHI
+            You're both right.
+
+                    TINKA/AZAZEL
+            (simultaneous)
+            Stay out of this!
+
+Tinka creates a burst of code-light, beautiful and dangerous. Azazel moves to contain it.
+
+                    TINKA
+            See? Control. Always control.
+
+                    AZAZEL
+            Because your way leads to chaos!
+
+                    TINKA
+            Maybe chaos is the answer! Maybe--
+
+SUDDENLY - All screens FLASH. A pattern emerges in their failed test results.
+
+Ryumi sees it first.
+
+                    RYUMI
+            Oh my god.
+
+                    PRIYANKA
+            What?
+
+                    RYUMI
+            It's not failing...
+            (beat)
+            It's dancing.
+
+They all stare at the pattern. Order and chaos. Control and freedom. Dancing together.
+
+Tinka and Azazel look at each other. Finally understanding.
+
+                    TINKA
+            We've been trying to write the story...
+
+                    AZAZEL
+            When we should have been letting it
+            write itself.
+
+Through the viewport: Their sun rises on a new possibility.
+
+FADE OUT.
+

--- a/agents/screenwriting/examples/tools_outline.md
+++ b/agents/screenwriting/examples/tools_outline.md
@@ -1,0 +1,40 @@
+# Screenwriting Tools Outline
+
+This document summarizes the utilities available in `agents/screenwriting`.
+
+## CharacterAnalyzer
+Evaluates character arcs and traits, using internal tools to inspect how characters develop.
+
+## CoWriter
+Collaborates on drafting or revising scenes by prompting creative responses from the model.
+
+## CreativeIdeas
+Generates plot twists, themes, and other conceptual prompts to inspire new material.
+
+## DialogueEvaluator
+Reviews dialogue for natural flow and offers suggestions for improvements.
+
+## EmotionalTension
+Assesses the emotional stakes throughout a script and suggests ways to adjust pacing or intensity.
+
+## Marketability
+Judges a story's commercial potential and audience appeal based on a synopsis.
+
+## PlotAnalyzer
+Examines overall plot structure and pacing, checking for coherence and balance.
+
+## ScriptFormatter
+Converts Fountain scripts into shareable HTML using the `fountain_to_html` instrument.
+
+## VersionTracker
+Maintains a history of screenplay revisions and notes.
+
+## ScreamAnalyzer *(new)*
+Identifies and highlights moments of heightened emotion or "screams" within text to ensure intense beats land effectively.
+
+---
+
+### Ideas for Further Enhancement
+- Integrate automated testing for pacing metrics.
+- Expand ScreamAnalyzer to classify different intensity levels.
+- Add tools for world-building consistency and visual storyboard generation.

--- a/agents/screenwriting/examples/tools_outline.md
+++ b/agents/screenwriting/examples/tools_outline.md
@@ -30,11 +30,23 @@ Converts Fountain scripts into shareable HTML using the `fountain_to_html` instr
 Maintains a history of screenplay revisions and notes.
 
 ## ScreamAnalyzer *(new)*
-Identifies and highlights moments of heightened emotion or "screams" within text to ensure intense beats land effectively.
+Identifies, highlights, and now classifies the intensity of emotional outbursts to ensure dramatic beats land effectively.
+
+## PacingMetrics *(new)*
+Computes basic pacing statistics, such as sentence counts and average sentence length, with automated tests.
+
+## WorldBuilder *(new)*
+Checks lore or setting notes for world-building consistency and contradictions.
+
+## StoryboardGenerator *(new)*
+Creates concise scene-by-scene visual prompts to aid storyboard artists.
+
+## MBTIEvaluator *(new)*
+Provides a lightweight MBTI-style personality assessment based on character descriptions.
 
 ---
 
 ### Ideas for Further Enhancement
-- Integrate automated testing for pacing metrics.
-- Expand ScreamAnalyzer to classify different intensity levels.
-- Add tools for world-building consistency and visual storyboard generation.
+- Visualize pacing metrics across acts or scenes.
+- Enrich MBTI evaluation with deeper narrative context.
+- Develop collaborative world-building editors with version tracking.

--- a/agents/screenwriting/mbti_evaluator.py
+++ b/agents/screenwriting/mbti_evaluator.py
@@ -1,0 +1,33 @@
+"""Lightweight MBTI-style personality evaluator for characters."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Tuple
+
+from agents import AgentConfig
+from .base import ScreenwritingAgent
+
+TRAITS: Tuple[Tuple[str, str, set[str], set[str]], ...] = (
+    ("I", "E", {"alone", "reflective", "quiet"}, {"team", "crowd", "party"}),
+    ("S", "N", {"detail", "practical", "real"}, {"imagine", "theory", "abstract"}),
+    ("T", "F", {"logic", "analysis"}, {"feeling", "empathy"}),
+    ("J", "P", {"plan", "schedule"}, {"adapt", "flexible", "spontaneous"}),
+)
+
+
+class MBTIEvaluator(ScreenwritingAgent):
+    """Score text against rough MBTI trait keywords."""
+
+    def __init__(self, number: int, config: AgentConfig, context=None):
+        super().__init__(number, config, context)
+
+    def evaluate(self, text: str) -> Dict[str, object]:
+        """Return raw trait scores and a best-guess type."""
+        words = re.findall(r"\w+", text.lower())
+        scores: Dict[str, int] = {trait: 0 for pair in TRAITS for trait in pair[:2]}
+        for a, b, set_a, set_b in TRAITS:
+            scores[a] += sum(1 for w in words if w in set_a)
+            scores[b] += sum(1 for w in words if w in set_b)
+        mbti = "".join(a if scores[a] >= scores[b] else b for a, b, *_ in TRAITS)
+        return {"type": mbti, "scores": scores}

--- a/agents/screenwriting/pacing_metrics.py
+++ b/agents/screenwriting/pacing_metrics.py
@@ -1,0 +1,27 @@
+"""Compute basic pacing metrics for a script."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+from agents import AgentConfig
+from .base import ScreenwritingAgent
+
+
+class PacingMetrics(ScreenwritingAgent):
+    """Calculate simple pacing statistics like sentence counts."""
+
+    def __init__(self, number: int, config: AgentConfig, context=None):
+        super().__init__(number, config, context)
+
+    def compute(self, script: str) -> Dict[str, float]:
+        """Return counts of sentences and average sentence length."""
+        sentences = [s.strip() for s in re.split(r"[.!?]+", script) if s.strip()]
+        word_counts = [len(s.split()) for s in sentences]
+        avg_len = sum(word_counts) / len(word_counts) if word_counts else 0.0
+        return {
+            "sentences": len(sentences),
+            "avg_sentence_length": avg_len,
+            "exclamations": script.count("!"),
+        }

--- a/agents/screenwriting/scream_analyzer.py
+++ b/agents/screenwriting/scream_analyzer.py
@@ -1,18 +1,40 @@
 """Agent that detects and analyzes intense emotional outbursts."""
 
+from typing import Literal
+
 from agents import AgentConfig
 from .base import ScreenwritingAgent
 
 
+Intensity = Literal["none", "low", "medium", "high"]
+
+
 class ScreamAnalyzer(ScreenwritingAgent):
-    """Identify moments of heightened emotion or screams within text."""
+    """Identify and classify moments of heightened emotion or screams."""
 
     def __init__(self, number: int, config: AgentConfig, context=None):
         super().__init__(number, config, context)
 
+    @staticmethod
+    def classify_intensity(text: str) -> Intensity:
+        """Classify intensity based on exclamation marks and all-caps words."""
+        exclamations = text.count("!")
+        caps = sum(1 for w in text.split() if w.isupper() and len(w) > 1)
+        score = exclamations + caps
+        if score > 5:
+            return "high"
+        if score > 2:
+            return "medium"
+        if score > 0:
+            return "low"
+        return "none"
+
     async def analyze(self, text: str) -> str:
-        """Use tools to highlight screams or similar exclamations in the text."""
+        """Highlight screams and return an intensity classification."""
+        intensity = self.classify_intensity(text)
         self.hist_add_user_message(
-            "Use available tools to analyze the following text for screams or intense emotional outbursts:\n" + text
+            "Use available tools to analyze the following text for screams or intense emotional outbursts:\n"
+            + text
         )
-        return await self.monologue()
+        details = await self.monologue()
+        return f"Intensity: {intensity}\n\n{details}"

--- a/agents/screenwriting/scream_analyzer.py
+++ b/agents/screenwriting/scream_analyzer.py
@@ -1,0 +1,18 @@
+"""Agent that detects and analyzes intense emotional outbursts."""
+
+from agents import AgentConfig
+from .base import ScreenwritingAgent
+
+
+class ScreamAnalyzer(ScreenwritingAgent):
+    """Identify moments of heightened emotion or screams within text."""
+
+    def __init__(self, number: int, config: AgentConfig, context=None):
+        super().__init__(number, config, context)
+
+    async def analyze(self, text: str) -> str:
+        """Use tools to highlight screams or similar exclamations in the text."""
+        self.hist_add_user_message(
+            "Use available tools to analyze the following text for screams or intense emotional outbursts:\n" + text
+        )
+        return await self.monologue()

--- a/agents/screenwriting/storyboard_generator.py
+++ b/agents/screenwriting/storyboard_generator.py
@@ -1,0 +1,18 @@
+"""Agent that produces a simple visual storyboard outline."""
+
+from agents import AgentConfig
+from .base import ScreenwritingAgent
+
+
+class StoryboardGenerator(ScreenwritingAgent):
+    """Generate scene-by-scene visual prompts for artists."""
+
+    def __init__(self, number: int, config: AgentConfig, context=None):
+        super().__init__(number, config, context)
+
+    async def generate(self, script: str) -> str:
+        """Use tools to craft a visual storyboard from script text."""
+        self.hist_add_user_message(
+            "Create a concise visual storyboard for the following script:\n" + script
+        )
+        return await self.monologue()

--- a/agents/screenwriting/test_pacing_metrics.py
+++ b/agents/screenwriting/test_pacing_metrics.py
@@ -1,0 +1,23 @@
+import models
+from agents import AgentConfig
+from .pacing_metrics import PacingMetrics
+
+
+def dummy_config():
+    mc = models.ModelConfig(type=models.ModelType.CHAT, provider="x", name="y")
+    ec = models.ModelConfig(type=models.ModelType.EMBEDDING, provider="x", name="y")
+    return AgentConfig(
+        chat_model=mc,
+        utility_model=mc,
+        embeddings_model=ec,
+        browser_model=mc,
+        mcp_servers="",
+    )
+
+
+def test_compute_basic():
+    agent = PacingMetrics(0, dummy_config())
+    metrics = agent.compute("Run! Jump. Stop?")
+    assert metrics["sentences"] == 3
+    assert metrics["exclamations"] == 1
+    assert metrics["avg_sentence_length"] > 0

--- a/agents/screenwriting/world_builder.py
+++ b/agents/screenwriting/world_builder.py
@@ -1,0 +1,18 @@
+"""Agent for checking world-building consistency."""
+
+from agents import AgentConfig
+from .base import ScreenwritingAgent
+
+
+class WorldBuilder(ScreenwritingAgent):
+    """Examine lore notes for continuity and logical coherence."""
+
+    def __init__(self, number: int, config: AgentConfig, context=None):
+        super().__init__(number, config, context)
+
+    async def check(self, bible: str) -> str:
+        """Use tools to verify world-building consistency."""
+        self.hist_add_user_message(
+            "Review the following world-building bible for consistency and contradictions:\n" + bible
+        )
+        return await self.monologue()


### PR DESCRIPTION
## Summary
- add cohesive `gaia_dreams.fountain` screenplay example derived from shared doc
- document available screenwriting tools and enhancement ideas
- implement `ScreamAnalyzer` to detect intense emotional outbursts

## Testing
- `pytest`
- `python -m py_compile agents/screenwriting/scream_analyzer.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5091648ec832781d23a70c986098a