### PR TITLE
Normalize tool name lookup and document egirl tool usage

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -811,6 +811,16 @@ class Agent:
     ):
         from python.tools.unknown import Unknown
         from python.helpers.tool import Tool
+        import re
+
+        def normalize_tool_name(tool_name: str) -> str:
+            """Convert various tool name formats to snake_case."""
+            tool_name = tool_name.strip()
+            tool_name = re.sub(r"(?<!^)(?=[A-Z])", "_", tool_name)
+            tool_name = re.sub(r"[^\w]", "_", tool_name)
+            return tool_name.lower()
+
+        normalized_name = normalize_tool_name(name)
 
         classes = []
 
@@ -818,22 +828,22 @@ class Agent:
         if self.config.profile:
             try:
                 classes = extract_tools.load_classes_from_file(
-                    "agents/" + self.config.profile + "/tools/" + name + ".py", Tool
+                    f"agents/{self.config.profile}/tools/{normalized_name}.py", Tool
                 )
-            except Exception as e:
+            except Exception:
                 pass
 
         # try default tools
         if not classes:
             try:
                 classes = extract_tools.load_classes_from_file(
-                    "python/tools/" + name + ".py", Tool
+                    f"python/tools/{normalized_name}.py", Tool
                 )
-            except Exception as e:
+            except Exception:
                 pass
         tool_class = classes[0] if classes else Unknown
         return tool_class(
-            agent=self, name=name, method=method, args=args, message=message, loop_data=loop_data, **kwargs
+            agent=self, name=normalized_name, method=method, args=args, message=message, loop_data=loop_data, **kwargs
         )
 
     async def call_extensions(self, extension_point: str, **kwargs) -> Any:

--- a/agents/egirl/prompts/agent.system.tool.egirl_tool.md
+++ b/agents/egirl/prompts/agent.system.tool.egirl_tool.md
@@ -1,4 +1,4 @@
-# EgirlTool
+### egirl_tool:
 - Use `task: post_instagram` with `image_url` and `caption` to publish a picture.
 - Use `task: comment_instagram` with `hashtags`, `text`, and optional `max_posts` to comment on posts.
 - Use `task: generate_image` with `prompt` and optional `output_dir` to create an image via Stable Diffusion.
@@ -9,3 +9,16 @@
 - Use `task: stripe_refund` with `payment_intent` to refund a payment.
 - Use `task: stripe_payout` with `amount` and optional `currency` to issue a payout.
 - Use `task: persona_chat` with `message` and optional `name` for a stylized reply.
+
+**Example usage**:
+~~~json
+{
+    "thoughts": ["..."] ,
+    "tool_name": "egirl_tool",
+    "tool_args": {
+        "task": "post_instagram",
+        "image_url": "https://example.com/image.jpg",
+        "caption": "hello"
+    }
+}
+~~~


### PR DESCRIPTION
## Summary
- Normalize tool names before loading to ensure agent-specific tools like EgirlTool resolve even if invoked with CamelCase
- Expand Egirl tool documentation with explicit name and example usage

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest`
- `python -m py_compile agents/agent.py agents/egirl/tools/egirl_tool.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6a727e6288327823937f45577646e