### PR TITLE
Add poker agent and expose code execution tool to agents

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -24,3 +24,6 @@ __all__ = [
 
 from .poker_ocr_agent import PokerOcrAgent
 __all__.append("PokerOcrAgent")
+
+from .poker import PokerAgent
+__all__.append("PokerAgent")

--- a/agents/egirl/tools/__init__.py
+++ b/agents/egirl/tools/__init__.py
@@ -1,10 +1,10 @@
 """Tool package for the egirl agent.
 
-Exposes the :class:`EgirlTool` so the agent can register it during
-dynamic tool discovery. Without this export the package was empty,
-which could prevent the tool from being located by the loader.
-"""
+Exposes the :class:`EgirlTool` and the shared :class:`CodeExecution`
+so the agent can register them during dynamic tool discovery."""
 
+from python.tools.code_execution_tool import CodeExecution
 from .egirl_tool import EgirlTool
 
-__all__ = ["EgirlTool"]
+__all__ = ["EgirlTool", "CodeExecution"]
+

--- a/agents/poker/__init__.py
+++ b/agents/poker/__init__.py
@@ -1,0 +1,48 @@
+"""Poker agent capable of evaluating poker hands.
+
+This agent demonstrates how domain specific logic can be combined with
+the generic :class:`~agents.agent.Agent` infrastructure.  It exposes a
+simple :meth:`evaluate_hand` helper that relies on the ``treys``
+library to compute a hand strength score."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from agents.agent import Agent, AgentConfig, AgentContext
+
+
+class PokerAgent(Agent):
+    """Agent that evaluates poker hands using the ``treys`` library."""
+
+    def __init__(
+        self,
+        number: int,
+        config: AgentConfig,
+        context: AgentContext | None = None,
+    ) -> None:
+        """Initialise the poker agent."""
+        super().__init__(number, config, context)
+
+    def evaluate_hand(self, cards: List[str]) -> Optional[int]:
+        """Return the strength of the provided hand.
+
+        Args:
+            cards: Two hole cards followed by up to five community cards.
+
+        Returns:
+            A numerical rank where lower values represent stronger hands.
+            ``None`` is returned if fewer than five cards are supplied.
+        """
+        if len(cards) < 5:
+            return None
+
+        from treys import Card, Evaluator
+
+        evaluator = Evaluator()
+        hole = [Card.new(c) for c in cards[:2]]
+        board = [Card.new(c) for c in cards[2:]]
+        return evaluator.evaluate(board, hole)
+
+__all__ = ["PokerAgent"]
+

--- a/agents/poker/_context.md
+++ b/agents/poker/_context.md
@@ -1,0 +1,4 @@
+# Poker Agent
+
+Provides utilities to evaluate poker hands and leverage the code execution
+tool for advanced analysis.

--- a/agents/poker/tools/__init__.py
+++ b/agents/poker/tools/__init__.py
@@ -1,0 +1,9 @@
+"""Tools for the poker agent.
+
+Currently only exposes the shared :class:`CodeExecution` tool.
+"""
+
+from python.tools.code_execution_tool import CodeExecution
+
+__all__ = ["CodeExecution"]
+

--- a/agents/screenwriting/prompts/agent.system.tool.code_exe.md
+++ b/agents/screenwriting/prompts/agent.system.tool.code_exe.md
@@ -1,0 +1,81 @@
+### code_execution_tool
+
+execute terminal commands python nodejs code for computation or software tasks
+place code in "code" arg; escape carefully and indent properly
+select "runtime" arg: "terminal" "python" "nodejs" "output" "reset"
+select "session" number, 0 default, others for multitasking
+if code runs long, use "output" to wait, "reset" to kill process
+use "pip" "npm" "apt-get" in "terminal" to install packages
+to output, use print() or console.log()
+if tool outputs error, adjust code before retrying; 
+important: check code for placeholders or demo data; replace with real variables; don't reuse snippets
+don't use with other tools except thoughts; wait for response before using others
+check dependencies before running code
+output may end with [SYSTEM: ...] information comming from framework, not terminal
+usage:
+
+1 execute python code
+
+~~~json
+{
+    "thoughts": [
+        "Need to do...",
+        "I can use...",
+        "Then I can...",
+    ],
+    "headline": "Executing Python code to check current directory",
+    "tool_name": "code_execution_tool",
+    "tool_args": {
+        "runtime": "python",
+        "session": 0,
+        "code": "import os\nprint(os.getcwd())",
+    }
+}
+~~~
+
+2 execute terminal command
+~~~json
+{
+    "thoughts": [
+        "Need to do...",
+        "Need to install...",
+    ],
+    "headline": "Installing zip package via terminal",
+    "tool_name": "code_execution_tool",
+    "tool_args": {
+        "runtime": "terminal",
+        "session": 0,
+        "code": "apt-get install zip",
+    }
+}
+~~~
+
+2.1 wait for output with long-running scripts
+~~~json
+{
+    "thoughts": [
+        "Waiting for program to finish...",
+    ],
+    "headline": "Waiting for long-running program to complete",
+    "tool_name": "code_execution_tool",
+    "tool_args": {
+        "runtime": "output",
+        "session": 0,
+    }
+}
+~~~
+
+2.2 reset terminal
+~~~json
+{
+    "thoughts": [
+        "code_execution_tool not responding...",
+    ],
+    "headline": "Resetting unresponsive terminal session",
+    "tool_name": "code_execution_tool",
+    "tool_args": {
+        "runtime": "reset",
+        "session": 0,
+    }
+}
+~~~

--- a/agents/screenwriting/prompts/agent.system.tools.md
+++ b/agents/screenwriting/prompts/agent.system.tools.md
@@ -1,0 +1,3 @@
+## Tools available:
+
+{{ include './agent.system.tool.code_exe.md' }}

--- a/agents/screenwriting/tools/__init__.py
+++ b/agents/screenwriting/tools/__init__.py
@@ -1,0 +1,9 @@
+"""Tools for the screenwriting agent.
+
+Currently exposes the shared :class:`CodeExecution` tool so the agent
+can run code via the ``code_execution_tool`` plugin."""
+
+from python.tools.code_execution_tool import CodeExecution
+
+__all__ = ["CodeExecution"]
+

--- a/python/tools/__init__.py
+++ b/python/tools/__init__.py
@@ -1,0 +1,11 @@
+"""Core tool package for Agent Zero.
+
+This package exposes built-in tools so they can be discovered by
+agent profiles.  Currently it registers the :class:`CodeExecution`
+plugin which provides the ``code_execution_tool`` used for running
+code and shell commands."""
+
+from .code_execution_tool import CodeExecution
+
+__all__ = ["CodeExecution"]
+


### PR DESCRIPTION
## Summary
- register `code_execution_tool` in core tools package
- expose `code_execution_tool` to egirl and screenwriting agents
- add new poker agent with code execution support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7e13c30d08327bb5b72ca783def0c