### PR TITLE
Add Stable Diffusion Colab guidance tool for egirl agent

### DIFF
--- a/agents/egirl/prompts/agent.system.tool.egirl_sd_colab_tool.md
+++ b/agents/egirl/prompts/agent.system.tool.egirl_sd_colab_tool.md
@@ -1,0 +1,33 @@
+### egirl_sd_colab_tool:
+- Use `task: overview` (aliases: `summary`, `colab_overview`) to recall the shared Stable Diffusion Colab link and the workspace layout on Google Drive.
+- Use `task: workflow` (aliases: `run`, `guide`, `colab_workflow`) with optional `prompt`, `negative_prompt`, `steps`, `guidance`, `num_images`, or `scheduler` values to get the full step-by-step plan for launching the notebook and running txt2img inside AUTOMATIC1111.
+- Use `task: download` (aliases: `fetch`, `colab_download`) with optional `filename`/`path` and boolean `as_zip` to receive ready-to-run snippets that download images or folders from the Colab runtime.
+
+**Example usage**:
+~~~json
+{
+    "thoughts": ["Open the shared Colab, generate an image, then download it."],
+    "tool_name": "egirl_sd_colab_tool",
+    "tool_args": {
+        "task": "workflow",
+        "prompt": "ultra-detailed portrait of an egirl hacker",
+        "negative_prompt": "low quality, blurry",
+        "steps": 30,
+        "guidance": 7.5,
+        "num_images": 2
+    }
+}
+~~~
+
+To download a finished render:
+~~~json
+{
+    "thoughts": ["Pull down the best render for posting."],
+    "tool_name": "egirl_sd_colab_tool",
+    "tool_args": {
+        "task": "download",
+        "filename": "2024-09-15/00012.png"
+    }
+}
+~~~
+

--- a/agents/egirl/prompts/agent.system.tools.md
+++ b/agents/egirl/prompts/agent.system.tools.md
@@ -21,3 +21,6 @@
 {{ include './agent.system.tool.document_query.md' }}
 
 {{ include './agent.system.tool.egirl_tool.md' }}
+
+{{ include './agent.system.tool.egirl_sd_colab_tool.md' }}
+

--- a/agents/egirl/tools/__init__.py
+++ b/agents/egirl/tools/__init__.py
@@ -1,10 +1,8 @@
-"""Tool package for the egirl agent.
-
-Exposes the :class:`EgirlTool` and the shared :class:`CodeExecution`
-so the agent can register them during dynamic tool discovery."""
+"""Tool package for the egirl agent."""
 
 from python.tools.code_execution_tool import CodeExecution
 from .egirl_tool import EgirlTool
+from .egirl_sd_colab_tool import EgirlStableDiffusionColabTool
 
-__all__ = ["EgirlTool", "CodeExecution"]
+__all__ = ["EgirlTool", "EgirlStableDiffusionColabTool", "CodeExecution"]
 

--- a/agents/egirl/tools/egirl_sd_colab_tool.py
+++ b/agents/egirl/tools/egirl_sd_colab_tool.py
@@ -1,0 +1,120 @@
+"""Tool exposing Stable Diffusion Colab guidance for the e-girl agent."""
+
+from __future__ import annotations
+
+from python.helpers.tool import Response, Tool
+from python.helpers.egirl import colab as colab_helper
+
+
+def _optional_int(value, *, label: str) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be an integer") from exc
+
+
+def _optional_float(value, *, label: str) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a number") from exc
+
+
+def _optional_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return False
+
+
+def _first_non_empty(kwargs: dict, *keys: str):
+    for key in keys:
+        value = kwargs.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+        if value not in (None, ""):
+            return value
+    return None
+
+
+class EgirlStableDiffusionColabTool(Tool):
+    """Provide instructions for using the shared Stable Diffusion Colab notebook."""
+
+    async def execute(self, **kwargs) -> Response:  # noqa: D401 - Tool protocol
+        task = (kwargs.get("task") or "").strip().lower()
+
+        try:
+            if task in {"overview", "colab_overview", "summary"}:
+                message = colab_helper.get_overview()
+                return Response(message=message, break_loop=False)
+
+            if task in {"workflow", "colab_workflow", "run", "guide"}:
+                prompt = _first_non_empty(kwargs, "prompt", "text", "positive_prompt")
+                negative_prompt = _first_non_empty(
+                    kwargs, "negative_prompt", "negative"
+                )
+                steps = _optional_int(
+                    _first_non_empty(kwargs, "steps", "num_inference_steps"),
+                    label="steps",
+                )
+                guidance = _optional_float(
+                    _first_non_empty(kwargs, "guidance", "cfg", "cfg_scale"),
+                    label="guidance",
+                )
+                num_images = _optional_int(
+                    _first_non_empty(kwargs, "num_images", "batch_count", "batch_size"),
+                    label="num_images",
+                )
+                scheduler = _first_non_empty(
+                    kwargs, "scheduler", "sampler", "sampling_method"
+                )
+
+                message = colab_helper.build_workflow(
+                    prompt=prompt,
+                    negative_prompt=negative_prompt,
+                    steps=steps,
+                    guidance=guidance,
+                    num_images=num_images,
+                    scheduler=scheduler,
+                )
+                return Response(message=message, break_loop=False)
+
+            if task in {"download", "colab_download", "fetch"}:
+                filename = _first_non_empty(
+                    kwargs,
+                    "filename",
+                    "path",
+                    "relative_path",
+                    "target",
+                    "output",
+                )
+                as_zip = _optional_bool(_first_non_empty(kwargs, "as_zip", "zip"))
+                message = colab_helper.build_download_instructions(
+                    filename=filename,
+                    as_zip=as_zip,
+                )
+                return Response(message=message, break_loop=False)
+
+            supported = "overview, workflow, download"
+            return Response(
+                message=f"unknown task '{task or '<empty>'}', supported: {supported}",
+                break_loop=False,
+            )
+        except ValueError as exc:
+            return Response(message=f"error: {exc}", break_loop=False)
+        except Exception as exc:  # pragma: no cover - defensive
+            return Response(message=f"error: {exc}", break_loop=False)
+

--- a/docs/egirl/stable_diffusion_colab.md
+++ b/docs/egirl/stable_diffusion_colab.md
@@ -1,0 +1,45 @@
+# Stable Diffusion Colab Pipeline
+
+Use the shared Google Colab notebook to launch AUTOMATIC1111's Stable Diffusion WebUI with persistent storage in Google Drive.
+
+## Notebook & Workspace
+- **Notebook:** https://colab.research.google.com/drive/1GsQ5_t3BRl4ibRgMK7ffgcoVKUSGC4Jl?usp=sharing
+- **Drive base folder:** `/content/drive/MyDrive/SD`
+  - Checkpoints → `/models/Stable-diffusion`
+  - VAEs → `/models/VAE`
+  - LoRAs → `/models/Lora`
+  - Embeddings → `/embeddings`
+  - Generated images → `/outputs`
+  - Optional dataset prep folders → `/datasets/egirl_blonde/`
+
+## Cell-by-Cell Instructions
+1. **Mount Drive / build folders** – approve the OAuth prompt; creates the directory structure above.
+2. **Install Python 3.10** – installs Python 3.10, pip and packaging tools required for AUTOMATIC1111.
+3. **Clone the repository** – clones `AUTOMATIC1111/stable-diffusion-webui` into `/content/sd-webui`.
+4. **Symlink to Drive assets** – ensures checkpoints, embeddings and outputs point at Drive so they persist between runs.
+5. **Install PyTorch CUDA 12.1 build** – installs `torch==2.1.2+cu121`, `torchvision==0.16.2+cu121`, matplotlib, torchmetrics, PyTorch Lightning, and OpenCV.
+6. **Launch the WebUI** – runs `launch.py` with `--medvram --opt-sdp-no-mem-attention --no-half-vae --theme dark --gradio-queue --share`. Wait for the `Running on public URL: ...` log entry.
+7. *(Optional)* **Dataset preparation** – resizes files from `/datasets/egirl_blonde/raw` to 512×768 PNGs and (when enabled) writes BLIP captions to `/datasets/egirl_blonde/prepared`.
+
+## Generating Images
+- Open the public Gradio link shown after the WebUI launches.
+- In **txt2img**, paste your prompt, set the negative prompt, sampler, CFG scale, steps, and batch count.
+- Click **Generate**; results land in `My Drive/SD/outputs/<date>` and remain persisted on Drive.
+
+## Download Options
+- **From Drive UI:** `My Drive → SD → outputs`.
+- **From the runtime:**
+  ```python
+  from google.colab import files
+  files.download('/content/drive/MyDrive/SD/outputs/<date>/<filename>.png')
+  ```
+- **Download everything as a zip:**
+  ```python
+  !zip -r /content/sd_outputs.zip /content/drive/MyDrive/SD/outputs
+  from google.colab import files
+  files.download('/content/sd_outputs.zip')
+  ```
+
+## Cleanup
+- Choose **Runtime → Disconnect and delete runtime** when finished to release the GPU.
+

--- a/python/helpers/egirl/colab.py
+++ b/python/helpers/egirl/colab.py
@@ -1,0 +1,257 @@
+"""Utilities for guiding the e-girl agent through the Stable Diffusion Colab."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import Iterable
+
+COLAB_NOTEBOOK_ID = "1GsQ5_t3BRl4ibRgMK7ffgcoVKUSGC4Jl"
+COLAB_NOTEBOOK_URL = (
+    f"https://colab.research.google.com/drive/{COLAB_NOTEBOOK_ID}?usp=sharing"
+)
+
+# Paths that the shared Colab notebook mounts inside Google Drive.
+DRIVE_BASE_PATH = "/content/drive/MyDrive/SD"
+MODELS_DIR = f"{DRIVE_BASE_PATH}/models/Stable-diffusion"
+VAE_DIR = f"{DRIVE_BASE_PATH}/models/VAE"
+LORA_DIR = f"{DRIVE_BASE_PATH}/models/Lora"
+EMBEDDINGS_DIR = f"{DRIVE_BASE_PATH}/embeddings"
+OUTPUTS_DIR = f"{DRIVE_BASE_PATH}/outputs"
+RAW_DATASET_DIR = f"{DRIVE_BASE_PATH}/datasets/egirl_blonde/raw"
+PREP_DATASET_DIR = f"{DRIVE_BASE_PATH}/datasets/egirl_blonde/prepared"
+
+DEFAULT_LAUNCH_FLAGS = (
+    "--medvram --opt-sdp-no-mem-attention --no-half-vae --theme dark "
+    "--gradio-queue --share"
+)
+
+
+def _numbered_steps(steps: Iterable[str]) -> str:
+    return "\n".join(f"{idx}. {step}" for idx, step in enumerate(steps, start=1))
+
+
+def get_overview() -> str:
+    """Return a concise description of the Colab workspace."""
+
+    summary = dedent(
+        f"""
+        Google Colab notebook: {COLAB_NOTEBOOK_URL}
+
+        Workspace layout on Google Drive:
+        • Base directory: {DRIVE_BASE_PATH}
+        • Stable Diffusion checkpoints: {MODELS_DIR}
+        • VAE files: {VAE_DIR}
+        • LoRA weights: {LORA_DIR}
+        • Textual inversion embeddings: {EMBEDDINGS_DIR}
+        • Generated outputs (mirrored from the WebUI): {OUTPUTS_DIR}
+        • Optional DreamBooth dataset staging:
+          - Raw assets folder: {RAW_DATASET_DIR}
+          - Prepared 512x768 set with BLIP captions: {PREP_DATASET_DIR}
+
+        Notebook cell overview:
+        1. Mounts Google Drive and ensures the folder structure exists.
+        2. Installs Python 3.10 and modern packaging tools required by AUTOMATIC1111.
+        3. Clones the AUTOMATIC1111/stable-diffusion-webui repository into /content.
+        4. Symlinks the WebUI's models, embeddings, and outputs folders to Drive.
+        5. Installs the CUDA 12.1 build of PyTorch plus supporting libraries.
+        6. Launches the WebUI with the flags: {DEFAULT_LAUNCH_FLAGS}.
+        7. (Optional) Prepares a DreamBooth-ready dataset with BLIP captions.
+        """
+    ).strip()
+
+    return summary
+
+
+def build_workflow(
+    prompt: str | None = None,
+    *,
+    negative_prompt: str | None = None,
+    steps: int | None = None,
+    guidance: float | None = None,
+    num_images: int | None = None,
+    scheduler: str | None = None,
+) -> str:
+    """Render a full step-by-step workflow for running the Colab notebook."""
+
+    prompt_section: list[str] = []
+    if prompt:
+        prompt_section.append(f"• Positive prompt: `{prompt}`")
+    if negative_prompt:
+        prompt_section.append(f"• Negative prompt: `{negative_prompt}`")
+    if steps is not None:
+        prompt_section.append(f"• Sampling steps: {steps}")
+    if guidance is not None:
+        prompt_section.append(f"• CFG guidance scale: {guidance}")
+    if num_images is not None:
+        prompt_section.append(f"• Batch count: {num_images}")
+    if scheduler:
+        prompt_section.append(f"• Sampler/scheduler: {scheduler}")
+
+    if prompt_section:
+        prompt_section_text = "\n".join(prompt_section)
+        prompt_section_text = (
+            "Suggested WebUI settings based on the request:\n" + prompt_section_text
+        )
+    else:
+        prompt_section_text = (
+            "Customize your prompts inside the AUTOMATIC1111 interface after it opens."
+        )
+
+    steps_text = _numbered_steps(
+        [
+            (
+                "Open the shared notebook and ensure the runtime uses a GPU: go to"
+                " Runtime → Change runtime type, pick `T4` under GPU, click Save,"
+                " then press Connect."
+            ),
+            (
+                "Run the first cell to mount Google Drive at `/content/drive` and"
+                " create the Stable Diffusion workspace directories. Approve the"
+                " OAuth dialog so the notebook can write to Drive."
+            ),
+            (
+                "Execute the environment bootstrap cell that installs Python 3.10"
+                " and pip. This takes a few minutes and only needs to run once per"
+                " fresh runtime."
+            ),
+            (
+                "Run the git clone cell to download"
+                " `AUTOMATIC1111/stable-diffusion-webui` into `/content/sd-webui`."
+            ),
+            (
+                "Execute the symlink cell so that models, VAEs, LoRAs, embeddings,"
+                " and outputs inside the WebUI point at your Drive folders."
+            ),
+            (
+                "Install the CUDA 12.1 build of PyTorch, torchmetrics,"
+                " pytorch-lightning, and optional OpenCV support."
+            ),
+            (
+                "Launch the WebUI with `launch.py` using the flags"
+                f" `{DEFAULT_LAUNCH_FLAGS}`. Wait until the log prints"
+                " `Running on public URL: https://...` (or `https://127.0.0.1`"
+                " when using Colab's UI preview)."
+            ),
+            (
+                "Open the provided public Gradio link in a new browser tab."
+                " Inside the txt2img tab, paste your prompt(s) and adjust"
+                " sampling parameters as needed."
+            ),
+            (
+                "Generate images. Every render is written to"
+                f" `{OUTPUTS_DIR}` on Google Drive (mirrored under"
+                " `/content/sd-webui/outputs`). Keep the WebUI tab open"
+                " until generation finishes."
+            ),
+            (
+                "When you are done, use Runtime → Disconnect and delete runtime"
+                " to clean up Colab resources."
+            ),
+        ]
+    )
+
+    download_section = dedent(
+        f"""
+        Downloading your results:
+        • Option A – Google Drive: open *My Drive → SD → outputs* to browse and
+          download the generated images directly from Drive.
+        • Option B – Direct download from the runtime:
+          ```python
+          from google.colab import files
+          files.download('{OUTPUTS_DIR}/<relative_path_to_image>.png')
+          ```
+        • Option C – Grab the entire outputs folder as a zip inside Colab:
+          ```python
+          !zip -r /content/sd_outputs.zip '{OUTPUTS_DIR}'
+          from google.colab import files
+          files.download('/content/sd_outputs.zip')
+          ```
+        """
+    ).strip()
+
+    optional_section = dedent(
+        f"""
+        Optional dataset preparation:
+        • The final cell in the notebook can resize images from
+          `{RAW_DATASET_DIR}` to 512×768 PNGs, and (when `use_blip = True`) create
+          BLIP captions alongside them in `{PREP_DATASET_DIR}`. Run it only if you
+          are preparing DreamBooth or LoRA training data."
+        """
+    ).strip()
+
+    return (
+        dedent(
+            f"""
+            Stable Diffusion WebUI workflow on Colab
+
+            Notebook link: {COLAB_NOTEBOOK_URL}
+
+            {steps_text}
+
+            {prompt_section_text}
+
+            {download_section}
+
+            {optional_section}
+            """
+        )
+        .strip()
+    )
+
+
+def build_download_instructions(
+    filename: str | None = None,
+    *,
+    as_zip: bool = False,
+) -> str:
+    """Return specific instructions for downloading generated assets."""
+
+    if filename:
+        target_path = f"{OUTPUTS_DIR}/{filename.lstrip('/')}"
+    else:
+        target_path = OUTPUTS_DIR
+
+    if as_zip:
+        command = dedent(
+            f"""
+            !zip -r /content/sd_outputs.zip '{target_path}'
+            from google.colab import files
+            files.download('/content/sd_outputs.zip')
+            """
+        ).strip()
+        description = (
+            "Zip the requested folder or file inside the runtime, then trigger a"
+            " browser download."
+        )
+    else:
+        command = dedent(
+            f"""
+            from google.colab import files
+            files.download('{target_path}')
+            """
+        ).strip()
+        description = (
+            "Download the specific file directly. If you provided a folder,"
+            " enable `as_zip` to bundle it first."
+        )
+
+    return (
+        dedent(
+            f"""
+            Direct download helper for the Stable Diffusion Colab
+
+            Target on Drive: {target_path}
+
+            {description}
+
+            ```python
+            {command}
+            ```
+
+            Remember that every render is also available via Google Drive at
+            {OUTPUTS_DIR}.
+            """
+        )
+        .strip()
+    )
+


### PR DESCRIPTION
## Summary
- add a reusable helper that captures the shared Stable Diffusion Colab workflow and download snippets
- expose the workflow via a new `egirl_sd_colab_tool` plus prompt updates so the agent can request instructions
- document the end-to-end Colab process, including how to fetch outputs, in repo docs for quick reference

## Testing
- python -m compileall agents/egirl/tools/egirl_sd_colab_tool.py python/helpers/egirl/colab.py

------
https://chatgpt.com/codex/tasks/task_e_68c8931bbd40832787dabfe0c82d2d7a