### PR TITLE
Handle optional dependencies for tools

### DIFF
--- a/python/helpers/browser_use.py
+++ b/python/helpers/browser_use.py
@@ -1,4 +1,55 @@
+"""Thin wrapper around the optional ``browser_use`` dependency.
+
+The Browser Agent tool relies on the external ``browser-use`` package.  In
+some environments this dependency is not installed by default (and the newest
+versions bring in conflicting transitive requirements).  Importing the tool
+module should therefore not fail outright – instead we expose a lightweight
+proxy that raises a helpful error message when the tool is actually used.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
 from python.helpers import dotenv
+
+
 dotenv.save_dotenv_value("ANONYMIZED_TELEMETRY", "false")
-import browser_use
-import browser_use.utils
+
+
+class _MissingBrowserUseAttr:
+    """Callable placeholder that raises a helpful import error when used."""
+
+    def __init__(self, exc: ModuleNotFoundError):
+        self._exc = exc
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "Optional dependency 'browser-use' is required for the browser agent "
+            "tool. Install it with `pip install browser-use` to enable this "
+            "functionality."
+        ) from self._exc
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover
+        raise ModuleNotFoundError(
+            "Optional dependency 'browser-use' is required for the browser agent "
+            "tool. Install it with `pip install browser-use` to enable this "
+            "functionality."
+        ) from self._exc
+
+
+class _MissingBrowserUseProxy:
+    """Fallback module-like object used when ``browser-use`` is missing."""
+
+    def __init__(self, exc: ModuleNotFoundError):
+        self._exc = exc
+
+    def __getattr__(self, item: str) -> Any:  # pragma: no cover - simple proxy
+        return _MissingBrowserUseAttr(self._exc)
+
+
+try:  # pragma: no cover - import guarded to support optional dependency
+    import browser_use  # type: ignore
+    import browser_use.utils  # type: ignore
+except ModuleNotFoundError as exc:  # pragma: no cover - executed when missing
+    browser_use = _MissingBrowserUseProxy(exc)  # type: ignore[assignment]

--- a/python/tools/__init__.py
+++ b/python/tools/__init__.py
@@ -5,7 +5,7 @@ agent profiles.  Currently it registers the :class:`CodeExecution`
 plugin which provides the ``code_execution_tool`` used for running
 code and shell commands."""
 
-from .code_execution_tool import CodeExecution
+from python.tools.code_execution_tool import CodeExecution
 
 __all__ = ["CodeExecution"]
 

--- a/python/tools/behaviour_update.py
+++ b/python/tools/behaviour_update.py
@@ -1,4 +1,4 @@
-from .behaviour_adjustment import UpdateBehaviour
+from python.tools.behaviour_adjustment import UpdateBehaviour
 
 
 class BehaviourUpdate(UpdateBehaviour):

--- a/python/tools/browser_agent.py
+++ b/python/tools/browser_agent.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 import time
 from typing import Optional

--- a/python/tools/memory_access.py
+++ b/python/tools/memory_access.py
@@ -1,4 +1,4 @@
-from .memory_load import MemoryLoad
+from python.tools.memory_load import MemoryLoad
 
 
 class MemoryAccess(MemoryLoad):


### PR DESCRIPTION
## Summary
- guard the browser agent helper so the tool loads without the optional `browser-use` package and raise a clear error when it is used without the dependency
- make document querying tolerant of missing `langchain-unstructured` and older `langchain-community` releases while preserving PDF fallbacks
- switch several tool modules to absolute imports (and future annotations) so they can be dynamically loaded without package context

## Testing
- `python -m compileall python/helpers/browser_use.py python/helpers/document_query.py python/tools/__init__.py python/tools/behaviour_update.py python/tools/browser_agent.py python/tools/memory_access.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8e014b0888327b07e3b6e63c9399a