### PR TITLE
Force RFC HTTP port to 5000 and fix Windows module import

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -217,7 +217,7 @@ class AgentConfig:
     code_exec_docker_name: str = "A0-dev"
     code_exec_docker_image: str = "agent0ai/agent-zero-run:development"
     code_exec_docker_ports: dict[str, int] = field(
-        default_factory=lambda: {"22/tcp": 55022, "80/tcp": 55080}
+        default_factory=lambda: {"22/tcp": 55022, "80/tcp": 5000}
     )
     code_exec_docker_volumes: dict[str, dict[str, str]] = field(
         default_factory=lambda: {

--- a/initialize.py
+++ b/initialize.py
@@ -82,7 +82,7 @@ def initialize_agent():
         code_exec_docker_enabled=False,
         # code_exec_docker_name = "A0-dev",
         # code_exec_docker_image = "agent0ai/agent-zero:development",
-        # code_exec_docker_ports = { "22/tcp": 55022, "80/tcp": 55080 }
+        # code_exec_docker_ports = { "22/tcp": 55022, "80/tcp": 5000 }
         # code_exec_docker_volumes = {
         # files.get_base_dir(): {"bind": "/a0", "mode": "rw"},
         # files.get_abs_path("work_dir"): {"bind": "/root", "mode": "rw"},


### PR DESCRIPTION
## Summary
- force the RFC HTTP endpoint builder to always target host port 5000 and update defaults/migrations to match
- normalize development RFC module paths so Windows callers import python helpers correctly
- align the agent Docker port defaults and documentation comment with the new 5000 HTTP host port

## Testing
- python -m compileall python/helpers/runtime.py python/helpers/settings.py python/helpers/files.py agents/agent.py initialize.py

------
https://chatgpt.com/codex/tasks/task_e_68c922ba1278832794fb7d17ceae642f