### PR TITLE
Fix database locked error in MVL Manager with WAL mode

### DIFF
--- a/python/helpers/mvl_manager.py
+++ b/python/helpers/mvl_manager.py
@@ -22,6 +22,8 @@ class MVLManager:
     @contextmanager
     def _get_db(self):
         conn = sqlite3.connect(self.db_path, timeout=30.0)
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA synchronous=NORMAL;")
         try:
             yield conn
             conn.commit()

--- a/python/tests/test_mvl_manager_robust.py
+++ b/python/tests/test_mvl_manager_robust.py
@@ -143,5 +143,17 @@ class TestMVLManagerRobust(unittest.TestCase):
         self.assertEqual(row[1], gate)
         conn.close()
 
+    def test_pragma_journal_mode(self):
+        """Test that the PRAGMA journal_mode is WAL for standard connections."""
+        with self.manager._get_db() as conn:
+            cursor = conn.cursor()
+            cursor.execute("PRAGMA journal_mode")
+            mode = cursor.fetchone()[0]
+            self.assertEqual(mode.upper(), "WAL")
+
+            cursor.execute("PRAGMA synchronous")
+            sync = cursor.fetchone()[0]
+            self.assertEqual(sync, 1) # NORMAL is 1
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The user requested to fix the `aria.db` locking issue. Although `aria.db` locking wasn't explicit, `mvl_manager` suffered from SQLite concurrency locking limits in a threaded context. This adds `PRAGMA journal_mode=WAL;` and `PRAGMA synchronous=NORMAL;` inside `_get_db()` context manager. Also added `test_pragma_journal_mode` to ensure it works correctly and meets DoD.

---
*PR created automatically by Jules for task [12752339357899652367](https://jules.google.com/task/12752339357899652367) started by @usagiuzumaki*