### PR TITLE
Fix documentation: Local setup requirements for SESSION_SECRET

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -67,6 +67,16 @@ playwright install chromium
 These will install all the python packages and browser binaries for playwright (browser agent).
 Errors in the code editor caused by missing packages should now be gone. If not, try reloading the window.
 
+4. Initialize environment variables. Create your `.env` file by copying the example:
+```bash
+cp .env.example .env
+```
+Open the `.env` file and set the required session secret:
+```
+SESSION_SECRET=your_dev_secret_here
+```
+*(Note: `run_ui.py` will throw a fatal error if this variable is missing).*
+
 
 ## Step 4: Run Aria - AI Creative Companion in the IDE
 Great work! Now you should be able to run Aria - AI Creative Companion from your IDE including real-time debugging.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -305,8 +305,12 @@ Aria - AI Creative Companion's Web UI is accessible from any device on your netw
 > [!NOTE]
 > If you're running Aria - AI Creative Companion directly on your system (legacy approach) instead of
 > using Docker, you'll need to configure the host manually in `run_ui.py` to run on all interfaces using `host="0.0.0.0"`.
+>
+> **Important:** To run `run_ui.py` locally without Docker, you must:
+> 1. Install dependencies: `pip install -r requirements.txt`
+> 2. Initialize environment variables: `cp .env.example .env` and explicitly set `SESSION_SECRET=your_dev_secret_here` inside the `.env` file (the application will fail to start without this secret).
 
-For developers or users who need to run Aria - AI Creative Companion directly on their system,see the [In-Depth Guide for Full Binaries Installation](#in-depth-guide-for-full-binaries-installation).
+For developers or users who need to run Aria - AI Creative Companion directly on their system, see the [Development Guide](./development.md) for full installation details.
 
 # How to update Aria - AI Creative Companion
 


### PR DESCRIPTION
What:
- Updated `docs/installation.md` to clarify the local fallback process.
- Updated `docs/development.md` to explicitly state the `.env` file requirements during IDE setup.

Why:
- Running `run_ui.py` immediately after cloning fails fatally without `SESSION_SECRET` and required pip modules installed.

How to test:
- Verify changes manually by reading docs. Follow the updated instructions on a clean clone to confirm they yield a working local environment.

Screenshots/video: N/A

Risks: None (documentation only)

Follow-ups: None

---
*PR created automatically by Jules for task [1797197792712775833](https://jules.google.com/task/1797197792712775833) started by @usagiuzumaki*